### PR TITLE
Staff Overview Page Layout Changes

### DIFF
--- a/webpages/StaffPage.php
+++ b/webpages/StaffPage.php
@@ -6,6 +6,8 @@ require_once('StaffCommonCode.php');
 staff_header($title,  true);
 ?>
 
+<div class="row">
+<div class="col-lg-8">
 <div class="card mt-2">
     <div class="card-header">
         <h2><?php echo CON_NAME; ?></h2>
@@ -38,13 +40,16 @@ if (!populateCustomTextArray()) {
     RenderError($message_error);
     exit();
 }
-echo "    <div class=\"card-body session-status-definitions\">";
+echo "    <div class=\"card-body\">";
 echo fetchCustomText("staff_overview");
 echo "    </div><!-- close card body -->";
 ?>
 </div><!-- close card top level -->
 
-<hr>
+</div>
+<div class="col-lg-4">
+
+<hr class="d-lg-none" />
 
 <div class="card mt-2">
 <?php
@@ -81,5 +86,7 @@ echo "    </div><!-- close card body -->\n";
 </p>
 </div><!-- close card top level -->
 
+</div>
+</div>
 
 <?php staff_footer(); ?>


### PR DESCRIPTION
This pull request changes the layout of the Staff Overview page, and puts the two cards side-by-side in an effort to use available space more effectively. 

The new version looks like this:

<img width="2124" alt="Screen Shot 2022-03-16 at 2 23 12 PM" src="https://user-images.githubusercontent.com/2981347/158660709-86d5e34a-4114-4fda-b04c-2c38a2c4b284.png">

This is purely a cosmetic change, and does not change any functionality.