### PR TITLE
Allow "Confirm assignment" on My Schedule page

### DIFF
--- a/Install/Upgrade_dbase/76WIS_add_confirmation_column.sql
+++ b/Install/Upgrade_dbase/76WIS_add_confirmation_column.sql
@@ -1,0 +1,15 @@
+## This script adds a new column to the ParticipantOnSession to track
+## whether or not a Participant has confirmed their attendance on the
+## session.
+##
+## Currently, the use of the ParticipantOnSession and ParticipantOnSessionHistory
+## table is complex and often driven by triggers. For now, I am ignoring 
+## the triggers, and will update the table directly when the participant 
+## confirms.
+##
+## Created by BC Holmes
+##
+ALTER TABLE `ParticipantOnSession` ADD COLUMN `confirmed` varchar(16);
+ALTER TABLE `ParticipantOnSession` ADD COLUMN `notes` text;
+
+INSERT INTO PatchLog (patchname) VALUES ('76WIS_add_confirmation_column.sql');

--- a/webpages/MySchedule.php
+++ b/webpages/MySchedule.php
@@ -107,17 +107,17 @@ if (!$registered) {
     echo "</div>";
 }
 
-?>
-
-<div class="alert alert-primary">Please take a moment to confirm your panel assignments.</div>
-
-<div class="card">
-    <div class="card-body">
-<?php
 $allowConfirmation = 'false';
 if (defined('CONFIRM_SESSION_ASSIGNMENT') && CONFIRM_SESSION_ASSIGNMENT === TRUE) {
     $allowConfirmation = 'true';
+?>
+    <div class="alert alert-primary">Please take a moment to confirm your panel assignments.</div>
+<?php 
 }
+?>
+<div class="card">
+    <div class="card-body">
+<?php
 
 RenderXSLT('my_schedule.xsl', array( "badgeid" => $badgeid, "allowConfirmation" => $allowConfirmation ), $resultXML);
 ?>

--- a/webpages/MySchedule.php
+++ b/webpages/MySchedule.php
@@ -23,6 +23,7 @@ SELECT
             S.progguiddesc,
             TY.typename,
             DATE_FORMAT(ADDTIME('$CON_START_DATIM', SCH.starttime),'%a %l:%i %p') AS starttime,
+            DATE_FORMAT(ADDTIME('$CON_START_DATIM', ADDTIME(SCH.starttime, S.duration)),'%l:%i %p') AS endtime,
             left(S.duration, 5) AS duration,
             S.persppartinfo,
             S.notesforpart
@@ -40,22 +41,18 @@ SELECT
 EOD;
 $queryArr["participants"] = <<<EOD
 SELECT
-        POS.sessionid,
-        CD.badgename,
-        P.pubsname,
-        P.sortedpubsname,
+        POS.participantonsessionid, P.badgeid, POS.sessionid, CD.badgename, P.pubsname, 
         IF (P.share_email=1, CD.email, NULL) AS email,
-        POS.moderator,
-        PSI.comments
+        POS.moderator, PSI.comments, POS.confirmed, POS.notes
     FROM
-                  ParticipantOnSession POS
-             JOIN CongoDump CD USING(badgeid)
-             JOIN Participants P USING(badgeid)
-        LEFT JOIN ParticipantSessionInterest PSI USING(sessionid, badgeid)
+				ParticipantOnSession POS
+		   JOIN CongoDump CD USING(badgeid)
+		   JOIN Participants P USING(badgeid)
+	  LEFT JOIN ParticipantSessionInterest PSI USING(sessionid, badgeid)
     WHERE
         POS.sessionid IN (
             SELECT sessionid FROM ParticipantOnSession WHERE badgeid='$badgeid'
-        )
+			)
     ORDER BY sessionid, moderator DESC;
 EOD;
 $resultXML = mysql_query_XML($queryArr);
@@ -81,30 +78,55 @@ if (!$result = mysqli_query_with_error_handling($query)) {
 $row = mysqli_fetch_array($result, MYSQLI_NUM);
 mysqli_free_result($result);
 $poscount = $row[0];
-if (!$regmessage || $regmessage == 'Not Registered') {
+$registered = true;
+if (!$regmessage) {
+    $registered = false;
     if ($poscount >= 3) {
-        $regmessage = "Not Registered.</span><span> " . fetchCustomText("enough_panels");
+        $regmessage = "not registered.</span><span> " . fetchCustomText("enough_panels");
     } else {
-        $regmessage = "Not Registered.</span><span> " . fetchCustomText("not_enough_panels");
+        $regmessage = "not registered.</span><span> " . fetchCustomText("not_enough_panels");
     }
 }
 participant_header($title, false, 'Normal', true);
-echo "<div class=\"alert alert-primary mt-2\"><p>Below is the list of all the panels for which you are scheduled.  If you need any changes";
-echo " to this schedule please contact <a class=\"alert-link\" href=\"mailto:$PROGRAM_EMAIL\"> Programming </a>.</p>\n";
+echo "<div class=\"container\">";
+echo "<div class=\"alert alert-primary mt-2\"><p>Below is the list of all the panels for which you are scheduled. If you need any changes";
+echo " to this schedule please contact <a class=\"alert-link\" href=\"mailto:$PROGRAM_EMAIL\">Programming</a>.</p>\n";
 echo fetchCustomText("all_panelists_1");
 echo fetchCustomText("all_panelists_2");
-echo fetchCustomText("all_panelists_3");
-echo "<p>Your registration status is: <span class=\"alert alert-info\">$regmessage</span>\n";
-echo "<p>If you have any questions, please contact <a class=\"alert-link\" href=\"mailto:$PROGRAM_EMAIL\"> Programming</a>. Thank you.</div>\n";
+echo "<p>Thank you &mdash; <a class=\"alert-link\" href=\"mailto:$PROGRAM_EMAIL\"> Programming </a></div>\n";
+
+if (!$registered) {
+
+    echo "<div class=\"alert alert-warning\">";
+    echo "You are not currently registered for " . CON_NAME . ".";
+    if ($poscount >= 3) {
+        echo fetchCustomText("enough_panels");
+    } else {
+        echo fetchCustomText("not_enough_panels");
+    }
+    echo "</div>";
+}
+
 ?>
+
+<div class="alert alert-primary">Please take a moment to confirm your panel assignments.</div>
 
 <div class="card">
     <div class="card-body">
 <?php
-RenderXSLT('my_schedule.xsl', array(), $resultXML);
+$allowConfirmation = 'false';
+if (defined('CONFIRM_SESSION_ASSIGNMENT') && CONFIRM_SESSION_ASSIGNMENT === TRUE) {
+    $allowConfirmation = 'true';
+}
+
+RenderXSLT('my_schedule.xsl', array( "badgeid" => $badgeid, "allowConfirmation" => $allowConfirmation ), $resultXML);
 ?>
     </div>
 </div>
+</div>
+<script type="text/javascript" src="js/planzExtension.js"></script>
+<script type="text/javascript" src="js/planzExtensionMySchedule.js"></script>
+
 <?php
 participant_footer();
 ?>

--- a/webpages/api/confirm_session_assignment.php
+++ b/webpages/api/confirm_session_assignment.php
@@ -1,0 +1,82 @@
+<?php
+// Created by BC Holmes on 2022-03-16.
+
+if (!include ('../../db_name.php')) {
+	include ('../../db_name.php');
+}
+
+require_once('./db_support_functions.php');
+require_once('./http_session_functions.php');
+
+function update_participant_confirmation($db, $sessionId, $participantSessionId, $badgeId, $confirmValue) {
+    $query = <<<EOD
+    UPDATE ParticipantOnSession
+      SET confirmed = ?
+    WHERE participantonsessionid = ?
+      AND sessionid = ?
+      AND badgeid = ?;
+ EOD;
+
+    $stmt = mysqli_prepare($db, $query);
+    mysqli_stmt_bind_param($stmt, "siis", $confirmValue, $participantSessionId, $sessionId, $badgeId);
+
+    if ($stmt->execute()) {
+        mysqli_stmt_close($stmt);
+    } else {
+        throw new DatabaseSqlException("The Update could not be processed: $query --> " . mysqli_error($db));
+    }
+}
+
+function update_participant_confirmation_notes($db, $sessionId, $participantSessionId, $badgeId, $notes) {
+    $query = <<<EOD
+    UPDATE ParticipantOnSession
+      SET notes = ?
+    WHERE participantonsessionid = ?
+      AND sessionid = ?
+      AND badgeid = ?;
+ EOD;
+
+    $stmt = mysqli_prepare($db, $query);
+    mysqli_stmt_bind_param($stmt, "siis", $notes, $participantSessionId, $sessionId, $badgeId);
+
+    if ($stmt->execute()) {
+        mysqli_stmt_close($stmt);
+    } else {
+        throw new DatabaseSqlException("The Update could not be processed: $query --> " . mysqli_error($db));
+    }
+}
+
+
+start_session_if_necessary();
+
+$db = connect_to_db();
+try {
+    if ($_SERVER['REQUEST_METHOD'] === 'POST' && isLoggedIn()) {
+
+        $json = file_get_contents('php://input');
+        $data = json_decode($json, true);
+
+        $badgeId = getLoggedInUserBadgeId();
+        if ($data && array_key_exists('sessionId', $data) && array_key_exists('participantSessionId', $data)
+             && array_key_exists('value', $data)) {
+
+            update_participant_confirmation($db, $data['sessionId'], $data['participantSessionId'], $badgeId, $data['value']);
+            http_response_code(204);
+        } else if ($data && array_key_exists('sessionId', $data) && array_key_exists('participantSessionId', $data)
+            && array_key_exists('notes', $data)) {
+
+            update_participant_confirmation_notes($db, $data['sessionId'], $data['participantSessionId'], $badgeId, $data['notes']);
+            http_response_code(204);
+        } else {
+            http_response_code(400); // badly-formatted request
+        }
+
+    } else if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+        http_response_code(401); // not authenticated
+    } else {
+        http_response_code(405); // method not allowed
+    }
+} finally {
+    $db->close();
+}
+?>

--- a/webpages/api/confirm_session_assignment.php
+++ b/webpages/api/confirm_session_assignment.php
@@ -1,8 +1,8 @@
 <?php
 // Created by BC Holmes on 2022-03-16.
 
-if (!include ('../../db_name.php')) {
-	include ('../../db_name.php');
+if (!include ('../config/db_name.php')) {
+	include ('../config/db_name.php');
 }
 
 require_once('./db_support_functions.php');

--- a/webpages/api/http_session_functions.php
+++ b/webpages/api/http_session_functions.php
@@ -11,6 +11,10 @@ function isLoggedIn() {
     return isset($_SESSION['badgeid']);
 }
 
+function getLoggedInUserBadgeId() {
+    return isLoggedIn() ? $_SESSION['badgeid'] : null;
+}
+
 function isProgrammingStaff() {
     return isLoggedIn() && may_I("Staff");
 }

--- a/webpages/config/db_name_sample.php
+++ b/webpages/config/db_name_sample.php
@@ -108,4 +108,6 @@ define("REPORT_INCLUDE_DIRECTORY", "/var/data/planz/");  // outside of web serve
 define("AUTO_SCHEDULER", FALSE); // enable the auto-scheduler feature
 
 define("PUBLIC_NEW_USER", FALSE); // allow new user creation from login screen
+
+define("CONFIRM_SESSION_ASSIGNMENT", TRUE); // Ask participants to confirm their assignments
 ?>

--- a/webpages/js/planzExtension.js
+++ b/webpages/js/planzExtension.js
@@ -1,0 +1,30 @@
+$(function() {
+    $.planz = $.planz || {};
+
+    $.planz.redirectToLogin = () => {
+        window.location = '/';
+    };
+
+    $.planz.clearAlerts = (alertType) => {
+        if (alertType) {
+            $('.alert-' + alertType).remove();
+        } else {
+           $('.alert').remove();
+        }
+    };
+
+    $.planz.simpleAlert = (severity, text) => {
+        let $alert = $('<div class="alert alert-' + severity + '" />');
+        $alert.text(text);
+
+        let $parent = $('.container');
+        if ($parent.length > 0) {
+            $parent.first().prepend($alert);
+        } else {
+            $parent = $('.navbar');
+            if ($parent.length > 0) {
+                $parent().first().after($alert);
+            }
+        }
+    };
+});

--- a/webpages/js/planzExtensionMySchedule.js
+++ b/webpages/js/planzExtensionMySchedule.js
@@ -1,0 +1,87 @@
+$(function() {
+
+    $.planz.mySchedule = {
+
+        timers: {},
+
+        postData: (data) => {
+            $('.alert-danger').remove();
+
+            $.ajax({ 
+                url: 'api/confirm_session_assignment.php',
+                method: 'POST',
+                contentType: "application/json; charset=UTF-8",
+                dataType: "json",
+                data: JSON.stringify(data),
+                success: function(data) {
+                    // nothing required
+                },
+                error: function(err) {
+                    if (err.status < 300) {
+                        // this isn't an error. Why am I in the error function? Bad jQuery; no biscuit.
+                    } else if (err.status == 401) {
+                        $.planz.redirectToLogin();
+                    } else {
+                        $.planz.simpleAlert('danger', 'There was a problem contacting the server. Your changes might not have been saved. Try again later?');
+                    }
+                }
+            });
+        },
+
+        sendConfirmation: (sessionId, participantSessionid, value) => {
+            $.planz.mySchedule.postData({
+                sessionId: sessionId,
+                participantSessionId: participantSessionid,
+                value: value
+            });
+        },
+
+        sendNotes: (sessionId, participantSessionid, notes) => {
+            $.planz.mySchedule.postData({
+                sessionId: sessionId,
+                participantSessionId: participantSessionid,
+                notes: notes
+            });
+        },
+
+        sendNotesWithDelay: (e) => {
+            let $field = $(e.target);
+            let sessionId = $field.data('sessionid');
+            let participantSessionid = $field.data("participantonsessionid");
+            let name = 'notes-' + sessionId;
+            let value = $field.val();
+
+            if ($.planz.mySchedule.timers[name]) {
+                clearTimeout($.planz.mySchedule.timers[name]);
+                $.planz.mySchedule.timers[name] = null;
+            }
+            $.planz.mySchedule.timers[name] = setTimeout(() => {
+                $.planz.mySchedule.sendNotes(sessionId, participantSessionid, value);
+            }, 1000);
+        }
+    }
+
+    $(".confirmation-select").change((e) => {
+        let $select = $(e.target);
+        let sessionId = $select.data("sessionid");
+        let participantSessionid = $select.data("participantonsessionid");
+        $.planz.mySchedule.sendConfirmation(sessionId, participantSessionid, $select.val());
+    });
+
+    $('input[type="text"]').on('keyup', (e) => {
+        $.planz.mySchedule.sendNotesWithDelay(e);
+    });
+
+    $('input[type="text"]').on('paste', (e) => {
+        setTimeout(function() {
+            $.planz.mySchedule.sendNotesWithDelay(e);
+        }, 0);
+    });
+
+    $('input[type="text"]').on('cut', (e) => {
+        setTimeout(function() {
+            $.planz.mySchedule.sendNotesWithDelay(e);
+        }, 0);
+    });
+
+});

--- a/webpages/reports/allpartschedwithconfirmation.php
+++ b/webpages/reports/allpartschedwithconfirmation.php
@@ -1,0 +1,223 @@
+<?php
+$report = [];
+$report['name'] = 'Participant Assignments with Confirmation Status';
+$report['multi'] = 'true';
+$report['output_filename'] = 'participant_assignment_confirmation_status.csv';
+$report['description'] = 'The schedule sorted by participant, then time limited to program participants';
+$report['categories'] = array(
+    'Programming Reports' => 20,
+    'GOH Reports' => 20,
+);
+$report['queries'] = [];
+$report['queries']['participants'] =<<<'EOD'
+SELECT DISTINCT
+        P.badgeid, P.pubsname, C.firstname, C.lastname
+    FROM
+             Participants P
+        JOIN CongoDump C USING (badgeid)
+        JOIN ParticipantOnSession POS USING (badgeid)
+        JOIN Sessions S USING (sessionid)
+        JOIN Schedule SCH USING (sessionid)
+        JOIN UserHasPermissionRole UHPR USING (badgeid)
+    WHERE
+        UHPR.permroleid = 3 /* Program Participant */
+    ORDER BY
+        IF(instr(P.pubsname,C.lastname)>0,C.lastname,substring_index(P.pubsname,' ',-1)),
+        C.firstname;
+EOD;
+$report['queries']['schedule'] =<<<'EOD'
+SELECT
+        P.pubsname, P.badgeid, POS.moderator, S.duration, R.roomname, R.function, TR.trackname, 
+        C.badgename, concat(C.firstname,' ',C.lastname) AS name,
+        S.sessionid, S.title, DATE_FORMAT(ADDTIME('$ConStartDatim$',SCH.starttime),'%a %l:%i %p') AS starttime,
+        POS.confirmed, POS.notes
+    FROM
+             Participants P
+        JOIN CongoDump C USING (badgeid)
+        JOIN ParticipantOnSession POS USING (badgeid)
+        JOIN Sessions S USING (sessionid)
+        JOIN Schedule SCH USING (sessionid)
+        JOIN Rooms R USING (roomid)
+        JOIN Tracks TR USING (trackid)
+    ORDER BY
+        IF(instr(P.pubsname,C.lastname)>0,C.lastname,substring_index(P.pubsname,' ',-1)),
+        C.firstname,
+	SCH.starttime;
+EOD;
+$report['xsl'] =<<<'EOD'
+<?xml version="1.0" encoding="UTF-8" ?>
+<xsl:stylesheet version="1.1" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+    <xsl:output encoding="UTF-8" indent="yes" method="html" />
+    <xsl:include href="xsl/reportInclude.xsl" />
+    <xsl:template match="/">
+        <xsl:choose>
+            <xsl:when test="doc/query[@queryName='participants']/row">
+                <table class="table table-sm table-bordered">
+                    <thead>
+                        <tr>
+                            <th>Pubsname</th>
+                            <th>Title</th>
+                            <th>Moderator ?</th>
+                            <th>Room Name</th>
+                            <th>Start Time</th>
+                            <th>Confirm</th>
+                            <th>Notes</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <xsl:for-each select="/doc/query[@queryName='participants']/row">
+                            <xsl:variable name="badgeid"><xsl:value-of select="@badgeid" /></xsl:variable>
+                            <xsl:call-template name="usersSchedule">
+                                <xsl:with-param name="badgeid" select = "@badgeid" />
+                                <xsl:with-param name="rowdata" select = "/doc/query[@queryName='schedule']/row[@badgeid = $badgeid]" />
+                            </xsl:call-template>
+                        </xsl:for-each>
+                    </tbody>
+                </table>
+            </xsl:when>
+            <xsl:otherwise>
+                <div class="alert alert-danger">No results found.</div>
+            </xsl:otherwise>                    
+        </xsl:choose>
+    </xsl:template>
+    
+    <xsl:template name="usersSchedule">
+        <xsl:param name="badgeid" />
+	    <xsl:param name="rowdata" />
+	    <xsl:for-each select="$rowdata">
+            <tr>
+                <xsl:choose>
+                    <xsl:when test="position() = 1">
+                        <td rowspan="{last()}" style="border-top-width:2px">
+                            <xsl:call-template name="showLinkedPubsname">
+                                <xsl:with-param name="badgeid" select = "@badgeid" />
+                                <xsl:with-param name="pubsname" select = "@pubsname" />
+                                <xsl:with-param name="badgename" select = "@badgename" />
+                                <xsl:with-param name="name" select = "@name" />
+                            </xsl:call-template>
+                        </td>
+                        <td style="border-top-width:2px">
+                            <xsl:call-template name="showSessionTitle">
+                                <xsl:with-param name="sessionid" select = "@sessionid" />
+                                <xsl:with-param name="title" select = "@title" />
+                            </xsl:call-template>
+                        </td>
+                        <td style="border-top-width:2px">
+                            <xsl:if test="@moderator='1'">Yes</xsl:if>
+                            <xsl:text disable-output-escaping="yes">&amp;nbsp;</xsl:text>
+                        </td>
+                        <td style="border-top-width:2px">
+                            <xsl:call-template name="showRoomName">
+                                <xsl:with-param name="roomid" select = "@roomid" />
+                                <xsl:with-param name="roomname" select = "@roomname" />
+                            </xsl:call-template>
+                        </td>
+                        <td style="border-top-width:2px">
+                            <xsl:value-of select="@starttime" />
+                        </td>
+                        <td style="border-top-width:2px">
+                            <xsl:choose>
+                                <xsl:when test="@confirmed = 'ACCEPTED'">
+                                    <xsl:text>Accepted</xsl:text>
+                                </xsl:when>
+                                <xsl:when test="@confirmed = 'DECLINED'">
+                                    <xsl:text>Declined</xsl:text>
+                                </xsl:when>
+                                <xsl:when test="@confirmed = 'MAYBE'">
+                                    <xsl:text>Maybe</xsl:text>
+                                </xsl:when>
+                                <xsl:otherwise>
+                                    <xsl:text>Unconfirmed</xsl:text>
+                                </xsl:otherwise>
+                            </xsl:choose>
+                        </td>
+                        <td style="border-top-width:2px">
+                            <xsl:value-of select="@notes" />
+                        </td>
+                    </xsl:when>
+                    <xsl:when test="position() = last()">
+                        <td style="border-bottom:2px">
+                            <xsl:call-template name="showSessionTitle">
+                                <xsl:with-param name="sessionid" select = "@sessionid" />
+                                <xsl:with-param name="title" select = "@title" />
+                            </xsl:call-template>
+                        </td>
+                        <td style="border-bottom:2px">
+                            <xsl:if test="@moderator='1'">Yes</xsl:if>
+                            <xsl:text disable-output-escaping="yes">&amp;nbsp;</xsl:text>
+                        </td>
+                        <td style="border-bottom:2px">
+                            <xsl:call-template name="showRoomName">
+                                <xsl:with-param name="roomid" select = "@roomid" />
+                                <xsl:with-param name="roomname" select = "@roomname" />
+                            </xsl:call-template>
+                        </td>
+                        <td style="border-bottom:2px">
+                            <xsl:value-of select="@starttime" />
+                        </td>
+                        <td style="border-top-width:2px">
+                            <xsl:choose>
+                                <xsl:when test="@confirmed = 'ACCEPTED'">
+                                    <xsl:text>Accepted</xsl:text>
+                                </xsl:when>
+                                <xsl:when test="@confirmed = 'DECLINED'">
+                                    <xsl:text>Declined</xsl:text>
+                                </xsl:when>
+                                <xsl:when test="@confirmed = 'MAYBE'">
+                                    <xsl:text>Maybe</xsl:text>
+                                </xsl:when>
+                                <xsl:otherwise>
+                                    <xsl:text>Unconfirmed</xsl:text>
+                                </xsl:otherwise>
+                            </xsl:choose>
+                        </td>
+                        <td style="border-top-width:2px">
+                            <xsl:value-of select="@notes" />
+                        </td>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <td>
+                            <xsl:call-template name="showSessionTitle">
+                                <xsl:with-param name="sessionid" select = "@sessionid" />
+                                <xsl:with-param name="title" select = "@title" />
+                            </xsl:call-template>
+                        </td>
+                        <td>
+                            <xsl:if test="@moderator='1'">Yes</xsl:if>
+                            <xsl:text disable-output-escaping="yes">&amp;nbsp;</xsl:text>
+                        </td>
+                        <td>
+                            <xsl:call-template name="showRoomName">
+                                <xsl:with-param name="roomid" select = "@roomid" />
+                                <xsl:with-param name="roomname" select = "@roomname" />
+                            </xsl:call-template>
+                        </td>
+                        <td>
+                            <xsl:value-of select="@starttime" />
+                        </td>
+                        <td>
+                            <xsl:choose>
+                                <xsl:when test="@confirmed = 'ACCEPTED'">
+                                    <xsl:text>Accepted</xsl:text>
+                                </xsl:when>
+                                <xsl:when test="@confirmed = 'DECLINED'">
+                                    <xsl:text>Declined</xsl:text>
+                                </xsl:when>
+                                <xsl:when test="@confirmed = 'MAYBE'">
+                                    <xsl:text>Maybe</xsl:text>
+                                </xsl:when>
+                                <xsl:otherwise>
+                                    <xsl:text>Unconfirmed</xsl:text>
+                                </xsl:otherwise>
+                            </xsl:choose>
+                        </td>
+                        <td>
+                            <xsl:value-of select="@notes" />
+                        </td>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </tr>
+        </xsl:for-each>
+    </xsl:template>
+</xsl:stylesheet>
+EOD;

--- a/webpages/xsl/my_schedule.xsl
+++ b/webpages/xsl/my_schedule.xsl
@@ -1,24 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
 	my_schedule
-	Created by Peter Olszowka on 2013-12-09.
+	Created by Peter Olszowka on 2013-12-09. Revisions by BC Holmes 2022-03-16.
 	Copyright (c) 2013-2021 Peter Olszowka. All rights reserved.
 -->
 <xsl:stylesheet version="1.1" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+    <xsl:param name="badgeid" select="''"/>
+    <xsl:param name="allowConfirmation" select="'true'"/>
 	<xsl:output encoding="UTF-8" indent="yes" method="html" />
 	<xsl:template match="/">
 		<xsl:choose>
 			<xsl:when test="doc/query[@queryName='sessions']/row">
-				<table class="table table-sm">
-					<col style="width:4em;" />
-					<col style="width:15%;" />
-					<col style="width:8em;" />
-					<col style="width:8em;" />
-					<col style="width:8em;" />
-					<col style="width:8em;" />
-					<col style="width:65%;" />
-					<xsl:apply-templates select="doc/query[@queryName='sessions']/row" />
-				</table>
+				<xsl:apply-templates select="doc/query[@queryName='sessions']/row" />
 			</xsl:when>
 			<xsl:otherwise>
 				<div class="alert alert-error">No schedule sessions found.</div>
@@ -27,90 +20,153 @@
 	</xsl:template>
 	
 	<xsl:template match="doc/query[@queryName='sessions']/row">
-		<tr>
-			<td>
-				<span class="badge badge-info"><xsl:value-of select="@sessionid" /></span>
-			</td>
-			<td colspan="7"></td>
-		</tr>
-		<tr>
-			<td colspan="2">
-				<span class="badge badge-primary"><xsl:value-of select="@title" /></span>
-			</td>
-			<td>
-				<span class="badge badge-primary" title="Room"><xsl:value-of select="@roomname" /></span>
-			</td>
-			<td>
-				<span class="badge badge-primary" title="Track"><xsl:value-of select="@trackname" /></span>
-			</td>
-			<td>
-				<span class="badge badge-primary" title="Type"><xsl:value-of select="@typename" /></span>
-			</td>
-			<td>
-				<span class="badge badge-primary"><xsl:value-of select="@starttime" /></span>
-			</td>
-			<td>
-				<span class="badge badge-primary">Duration: <xsl:value-of select="@duration" /></span>
-			</td>
-			<td></td>
-		</tr>
-		<tr>
-			<td></td>
-			<td colspan="7">
-				<span class="badge badge-secondary">Description</span>
-				<span><xsl:text> </xsl:text><xsl:value-of select="@progguiddesc" /></span>
-			</td>
-		</tr>
-		<xsl:if test="@persppartinfo">
-			<tr>
-				<td></td>
-				<td colspan="7">
-					<span class="badge badge-secondary">Prospective participant information</span>
+		<div class="mb-5">
+			<h5 class="mb-0"><xsl:value-of select="@title" disable-output-escaping="yes"/></h5>
+			<div>
+				<b>
+					<span><xsl:value-of select="@roomname" /></span>
+					<xsl:text> &#8226; </xsl:text>
+					<span><xsl:value-of select="@trackname" /></span>
+					<xsl:text> &#8226; </xsl:text>
+					<span><xsl:value-of select="@typename" /></span>
+					<xsl:text> &#8226; </xsl:text>
+					<span><xsl:value-of select="@starttime" /><xsl:text>&#8211;</xsl:text><xsl:value-of select="@endtime" /></span>
+				</b>
+			</div>
+			<div class="my-2"><xsl:value-of select="@progguiddesc" disable-output-escaping="yes"/></div>
+			<xsl:if test="@persppartinfo">
+				<div class="my-2">
+					<b>Prospective participant information:</b>
 					<span><xsl:text> </xsl:text><xsl:value-of select="@persppartinfo" /></span>
-				</td>
-			</tr>
-		</xsl:if>
-		<xsl:if test="@notesforpart">
-			<tr>
-				<td></td>
-				<td colspan="7">
-					<span class="badge badge-secondary">Notes for participants</span>
+				</div>
+			</xsl:if>
+			<xsl:if test="@notesforpart">
+				<div class="my-2">
+					<b>Notes for participants:</b>
 					<span><xsl:text> </xsl:text><xsl:value-of select="@notesforpart" /></span>
-				</td>
-			</tr>
-		</xsl:if>
-		<tr>
-			<td></td>
-			<td>
-				<span class="badge badge-secondary">Panelists' Publication Names (Badge Names)</span>
-			</td>
-			<td colspan="2">
-				<span class="badge badge-secondary">Email addresses</span>
-			</td>
-			<td colspan="4">
-				<span class="badge badge-secondary">Comments</span>
-			</td>
-		</tr>
-		<xsl:variable name="sessionid" select="@sessionid" />
-		<xsl:apply-templates select="/doc/query[@queryName='participants']/row[@sessionid = $sessionid]" />
+				</div>
+			</xsl:if>
+			<xsl:variable name="sessionid" select="@sessionid" />
+			<xsl:apply-templates select="/doc/query[@queryName='participants']/row[@sessionid = $sessionid]" />
+		</div>
 	</xsl:template>
 
 	<xsl:template match="/doc/query[@queryName='participants']/row">
-		<tr>
-			<td></td>
-			<td>
-				<span><xsl:value-of select="@pubsname" /></span>
-				<span><xsl:text> (</xsl:text><xsl:value-of select="@badgename" /><xsl:text>)</xsl:text></span>
+		<div>
+			<xsl:attribute name="class">
+				<xsl:choose>
+					<xsl:when test="@badgeid = $badgeid">
+						<xsl:text>row align-items-baseline</xsl:text>
+					</xsl:when>
+					<xsl:otherwise>
+						<xsl:text>row mb-2 align-items-baseline</xsl:text>
+					</xsl:otherwise>
+				</xsl:choose>
+			</xsl:attribute>
+			<div class="col-lg-3">
 				<xsl:if test="@moderator = '1'">
-					<span style="font-style:italic;"><xsl:text> mod</xsl:text></span>
+					<b><xsl:text>Mod: </xsl:text></b>
 				</xsl:if>
-			</td>
-			<td colspan="2">
-				<span><xsl:value-of select="@email" /></span>
-			</td>
-			<td colspan="4">
-				<span><xsl:value-of select="@comments" /></span>
-			</td>
-		</tr>
+				<span><xsl:value-of select="@pubsname" disable-output-escaping="yes"/></span>
+				<xsl:if test="not(@pubsname = @badgename)">
+					<span><xsl:text> (</xsl:text><xsl:value-of select="@badgename" disable-output-escaping="yes"/><xsl:text>)</xsl:text></span>
+				</xsl:if>
+				<xsl:text> </xsl:text>
+			</div>
+			<xsl:if test="$allowConfirmation = 'true'">
+				<div class="col-lg-3">
+					<xsl:choose>
+						<xsl:when test="@badgeid = $badgeid">
+							<div class="form-group">
+								<xsl:element name="label">
+									<xsl:attribute name="class"><xsl:text>sr-only</xsl:text></xsl:attribute>
+									<xsl:attribute name="id"><xsl:text>select-pos-</xsl:text><xsl:value-of select="@participantonsessionid" /></xsl:attribute>
+									<xsl:text>Confirm Your Involvement</xsl:text>
+								</xsl:element>
+								<xsl:element name="select">
+									<xsl:attribute name="class"><xsl:text>form-control confirmation-select</xsl:text></xsl:attribute>
+									<xsl:attribute name="name"><xsl:text>availability</xsl:text></xsl:attribute>
+									<xsl:attribute name="data-sessionid"><xsl:value-of select="@sessionid" /></xsl:attribute>
+									<xsl:attribute name="data-participantonsessionid"><xsl:value-of select="@participantonsessionid" /></xsl:attribute>
+									<xsl:attribute name="id"><xsl:text>select-pos-</xsl:text><xsl:value-of select="@participantonsessionid" /></xsl:attribute>
+									<option value="">Please confirm...</option>
+									<option value="ACCEPTED">
+										<xsl:if test="@confirmed = 'ACCEPTED'">
+											<xsl:attribute name="selected"><xsl:text>selected</xsl:text></xsl:attribute>
+										</xsl:if>
+										<xsl:text>Yes, I'll be on the session</xsl:text>
+									</option>
+									<option value="DECLINED">
+										<xsl:if test="@confirmed = 'DECLINED'">
+											<xsl:attribute name="selected"><xsl:text>selected</xsl:text></xsl:attribute>
+										</xsl:if>
+										<xsl:text>No, this doesn't work</xsl:text>
+									</option>
+									<option value="MAYBE">
+										<xsl:if test="@confirmed = 'MAYBE'">
+											<xsl:attribute name="selected"><xsl:text>selected</xsl:text></xsl:attribute>
+										</xsl:if>
+										<xsl:text>Maybe</xsl:text>
+									</option>
+								</xsl:element>
+							</div>
+						</xsl:when>
+						<xsl:otherwise>
+							<xsl:choose>
+								<xsl:when test="@confirmed = 'ACCEPTED'">
+									<xsl:text>Accepted</xsl:text>
+								</xsl:when>
+								<xsl:when test="@confirmed = 'DECLINED'">
+									<xsl:text>Declined</xsl:text>
+								</xsl:when>
+								<xsl:when test="@confirmed = 'MAYBE'">
+									<xsl:text>Maybe</xsl:text>
+								</xsl:when>
+								<xsl:otherwise>
+									<xsl:text>Unconfirmed</xsl:text>
+								</xsl:otherwise>
+							</xsl:choose>
+						</xsl:otherwise>
+					</xsl:choose>
+				</div>
+			</xsl:if>
+			<div class="col-lg-3">
+				<xsl:choose>
+					<xsl:when test="@email != ''">
+						<xsl:element name="a">
+							<xsl:attribute name="href"><xsl:text>mailto:</xsl:text><xsl:value-of select="@email" /></xsl:attribute>
+							<xsl:value-of select="@email" />
+						</xsl:element>
+					</xsl:when>
+					<xsl:otherwise>
+						<span>Email not available</span>
+					</xsl:otherwise>
+				</xsl:choose>
+			</div>
+			<div>
+				<xsl:attribute name="class">
+					<xsl:choose>
+						<xsl:when test="$allowConfirmation = 'true'">
+							<xsl:text>col-lg-3</xsl:text>
+						</xsl:when>
+						<xsl:otherwise>
+							<xsl:text>col-lg-6</xsl:text>
+						</xsl:otherwise>
+					</xsl:choose>
+				</xsl:attribute>
+				<xsl:value-of select="@comments" />
+			</div>
+		</div>
+		<xsl:if test="@badgeid = $badgeid and $allowConfirmation = 'true'">
+			<div class="row mb-2 align-items-baseline">
+				<div class="form-group offset-lg-3 col-lg-9">
+					<input type="text" class="form-control" name="notes" placeholder="Anything you need us to know?">
+						<xsl:attribute name="data-sessionid"><xsl:value-of select="@sessionid" /></xsl:attribute>
+						<xsl:attribute name="data-participantonsessionid"><xsl:value-of select="@participantonsessionid" /></xsl:attribute>
+						<xsl:attribute name="value"><xsl:value-of select="@notes" /></xsl:attribute>
+					</input>
+				</div>
+			</div>
+		</xsl:if>
 	</xsl:template>
 </xsl:stylesheet>


### PR DESCRIPTION
In some cons, the programming team assigns folks to a panel, and then the participants confirms that they accept the assignment (or, for example, provide feedback such as "It turns out I'm not going to be at the con until 12 hours after I originally thought, so I can't make this panel.") 

This PR provides the ability to enable session confirmation from the "My Schedule" page. When turned on, the page looks like so:

<img width="1204" alt="Screen Shot 2022-03-16 at 11 13 40 PM" src="https://user-images.githubusercontent.com/2981347/158730956-5a90ea26-5078-407f-b138-8902c90d6926.png">

but without that function turned on, it looks like this:

<img width="1144" alt="Screen Shot 2022-03-16 at 11 28 51 PM" src="https://user-images.githubusercontent.com/2981347/158731092-e419ed62-9ffb-43e6-a81a-0b468b9592df.png">

The selections are stored via an Ajax/REST call.

I've also made a copy of the zambiaExtensions.js (called planzExtensions.js) to use as a base for the jQuery extension for this page. Going forward, I think we can migrate all of those extension files to use the planz name.

There is no db_name_sample.php in the repo, but the addition I would have added, there looks like this:

define("CONFIRM_SESSION_ASSIGNMENT", FALSE);