### PR TITLE
Move reference to Brainstorm file.

### DIFF
--- a/webpages/SubmitEditCreateSession.php
+++ b/webpages/SubmitEditCreateSession.php
@@ -3,12 +3,12 @@
     $action=$_POST["action"]; // "create" or "edit" or "brainstorm"
     if ($action=="brainstorm") {
             require_once ('BrainstormCommonCode.php');
+            require_once ('BrainstormRenderCreateSession.php');
             }
         else {
             require_once ('StaffCommonCode.php');
             }
     require_once ('RenderEditCreateSession.php');
-    require_once ('BrainstormRenderCreateSession.php');
     //session_start();
     global $name, $email, $messages;
     $messages="";


### PR DESCRIPTION
This new version has Brainstorm stuff moved, but there are still references to the old Brainstorm stuff in the code. This file had a reference that was being called from outside a brainstorm action and that caused an issue. I moved the call to within the brainstorm action.
This file needs to be changed to remove all the old brainstorm references I think. I haven't looked closely at the new brainstorm logic yet.