### PR TITLE
Fix session feedback

### DIFF
--- a/Install/Upgrade_dbase/78ZED_feedback_phase.sql
+++ b/Install/Upgrade_dbase/78ZED_feedback_phase.sql
@@ -1,0 +1,15 @@
+## Adds permission to Administrator role.
+##
+## Created by Leane Verhulst
+##
+
+INSERT INTO `Permissions` (permatomid, phaseid, permroleid)
+SELECT a.permatomid, p.phaseid, r.permroleid
+FROM PermissionAtoms a,
+     Phases p,
+     PermissionRoles r
+WHERE a.permatomtag = 'SessionFeedback'
+  AND p.phasename = 'Feedback and Interest'
+  AND r.permrolename = 'Administrator';
+
+INSERT INTO PatchLog (patchname) VALUES ('78ZED_feedback_phase.sql');

--- a/webpages/PartPanelInterests_FNC.php
+++ b/webpages/PartPanelInterests_FNC.php
@@ -135,7 +135,7 @@ function update_session_interests_in_db($badgeid, $session_interest_count) {
     }
     if ($noDeleteCount) {
         $noDeleteCount = 0;
-        $query = "REPLACE INTO ParticipantSessionInterest (badgeid, sessionid, rank, willmoderate, comments) VALUES ";
+        $query = "REPLACE INTO ParticipantSessionInterest (badgeid, sessionid, `rank`, willmoderate, comments) VALUES ";
         for ($i = 1; $i <= $session_interest_count; $i++) {
             if ($session_interests[$i]['delete'])
                 continue;

--- a/webpages/ParticipantHeader.php
+++ b/webpages/ParticipantHeader.php
@@ -72,7 +72,7 @@ function participant_header($title, $noUserRequired = false, $loginPageStatus = 
                             <?php } ?>
                             <?php makeMenuItem("Availability", may_I('my_availability'),"my_sched_constr.php",false); ?>
                             <?php makeMenuItem("General Interests",1,"my_interests.php",false); ?>
-                            <?php makeMenuItem("My Suggestions",1,"my_suggestions.php",false); ?>
+                            <?php makeMenuItem("My Suggestions", may_I('my_suggestions_write'),"my_suggestions.php",false); ?>
                             <?php makeMenuItem("Search Sessions", may_I('search_panels'),"PartSearchSessions.php", false); ?>
                             <?php makeMenuItem("Session Interests", may_I('my_panel_interests'),"PartPanelInterests.php",false); ?>
                             <?php makeMenuItem("My Schedule", may_I('my_schedule'),"MySchedule.php",false); ?>

--- a/webpages/api/session_feedback_list.php
+++ b/webpages/api/session_feedback_list.php
@@ -47,8 +47,7 @@ function find_session_for_feedback($db, $badgeid, $term) {
       JOIN PubStatuses ps USING (pubstatusid)
       LEFT OUTER JOIN ParticipantSessionInterest psi on psi.sessionid = s.sessionid and psi.badgeid = ?
      WHERE ss.may_be_scheduled = 1
-       AND ps.pubstatusname = 'Public'
-       AND s.divisionid in (select divisionid from Divisions where divisionname = 'Panels')
+       AND ps.pubstatusid = 2
        $clause
      ORDER BY t.display_order, s.sessionid;
 EOD;

--- a/webpages/xsl/SessionFeedback.xsl
+++ b/webpages/xsl/SessionFeedback.xsl
@@ -49,7 +49,7 @@
             </div>
         </div>
     </div>
-    <script type="text/javascript" src="javascript/zambiaExtension.js" />
-    <script type="text/javascript" src="javascript/zambiaExtensionFeedback.js" />
+    <script type="text/javascript" src="js/zambiaExtension.js" />
+    <script type="text/javascript" src="js/zambiaExtensionFeedback.js" />
   </xsl:template>
 </xsl:stylesheet>


### PR DESCRIPTION
Found a couple of references that needed to be changed for the Session Feedback. There was a reference to a "Panels" division which didn't exist, so I removed that line. There was also a reference to the name of the PubStatus, but it should really point to the id.
There was also a reference to the old javascript folder which I changed to the new js folder.
And a couple of other small bugs.