### PR TITLE
More session feedback fixes

### DIFF
--- a/Install/Upgrade_dbase/79ZED_add_partsessioninterest_field.sql
+++ b/Install/Upgrade_dbase/79ZED_add_partsessioninterest_field.sql
@@ -4,6 +4,6 @@
 ## Created by Leane Verhulst
 ##
 
-ALTER TABLE `Divisions` ADD COLUMN `allow_partSessionInterest` tinyint(1) NOT NULL DEFAULT 0;
+ALTER TABLE `Divisions` ADD COLUMN `is_part_session_interest_allowed` tinyint(1) NOT NULL DEFAULT 0;
 
 INSERT INTO PatchLog (patchname) VALUES ('79ZED_add_partsessioninterest_field.sql');

--- a/Install/Upgrade_dbase/79ZED_add_partsessioninterest_field.sql
+++ b/Install/Upgrade_dbase/79ZED_add_partsessioninterest_field.sql
@@ -1,0 +1,9 @@
+## This script adds a new column to the Divisions table to identify
+## which divisions will allow a participant to enter session feedback/interest.
+##
+## Created by Leane Verhulst
+##
+
+ALTER TABLE `Divisions` ADD COLUMN `allow_partSessionInterest` tinyint(1) NOT NULL DEFAULT 0;
+
+INSERT INTO PatchLog (patchname) VALUES ('79ZED_add_partsessioninterest_field.sql');

--- a/webpages/PartPanelInterests_Render.php
+++ b/webpages/PartPanelInterests_Render.php
@@ -2,7 +2,7 @@
 // Copyright (c) 2009-2018 Peter Olszowka. All rights reserved. See copyright document for more details.
 function render_session_interests($session_interest_count,$message,$message_error, $pageIsDirty, $showNotAttendingWarning) {
     global $session_interests, $title;
-    participant_header($title);
+    participant_header($title, false, 'Normal', false);
     if ($showNotAttendingWarning) {
         echo "<div class=\"alert alert-block\" style=\"margin:15px 0;\">\n";
         echo "    <h4>Warning!</h4>\n";
@@ -41,7 +41,7 @@ function render_session_interests($session_interest_count,$message,$message_erro
     echo "<hr />\n";
     // "Update Ranks" Section
     echo "<form id=\"sessionFRM\" class=\"form-inline\" name=\"sessionform\" method=\"POST\" action=\"PartPanelInterests_POST2.php\">\n";
-	echo "<input type=\"hidden\" name=\"submitranks\" value=\"1\" />\n";
+    echo "<input type=\"hidden\" name=\"submitranks\" value=\"1\" />\n";
     echo "<div class=\"submit\"><button class=\"btn btn-primary pull-right\" type=\"submit\" $disabled>Save</button></div>\n";
     echo "<p>Please use the following scale when ranking your interest in the sessions you have chosen:  </p>\n";
     echo "<strong>1 &mdash;<em> Oooh! Oh! Pick Me!</em>&nbsp;&nbsp;&nbsp;2-3 &mdash; <em>I'd like to if I can</em>&nbsp;&nbsp;&nbsp;4-5 &ndash; <em>I am qualified but this is not one of my primary interests</em></strong>\n";
@@ -70,7 +70,7 @@ function render_session_interests($session_interest_count,$message,$message_erro
         echo "            <label class=\"inline\">I'd like to moderate this session </label>\n";
         echo "        </span>\n";
         echo "        <span class=\"span4\">\n";
-        echo "            <input type=\"checkbox\" id=\"deleteCHK_$j\" class=\"checkbox\" value=\"1\" name=\"delete$j\" $disabled/>\n";		
+        echo "            <input type=\"checkbox\" id=\"deleteCHK_$j\" class=\"checkbox\" value=\"1\" name=\"delete$j\" $disabled/>\n";
         echo "            <label class=\"inline \">Remove this session from my list </label>\n";
         echo "        </span>\n";
         echo "    </div>\n";
@@ -97,7 +97,7 @@ function render_session_interests($session_interest_count,$message,$message_erro
     }
     echo "</div>\n";
     echo "<div class=\"submit\"><button class=\"btn btn-primary pull-right\" type=\"submit\" $disabled>Save</button></div><br />\n";
-	echo "<input type=\"hidden\" id=\"autosaveHID\" name=\"autosave\" value=\"0\" />\n";
+    echo "<input type=\"hidden\" id=\"autosaveHID\" name=\"autosave\" value=\"0\" />\n";
     echo "</form>\n";
     echo "<div id=\"addButDirtyMOD\" class=\"modal hide\" data-backdrop=\"static\">\n";
     echo "  <div class=\"modal-header\">\n";

--- a/webpages/ParticipantHeader.php
+++ b/webpages/ParticipantHeader.php
@@ -47,6 +47,7 @@ function participant_header($title, $noUserRequired = false, $loginPageStatus = 
             $paramArray["title"] = $title;
             $paramArray["my_suggestions"] = may_I('my_suggestions_write') ? true : false;
             $paramArray["SessionFeedback"] = may_I('SessionFeedback') ? true : false;
+            $paramArray["SessionInterests"] = may_I('my_panel_interests') ? true : false;
             $paramArray["survey"] = array_key_exists('survey_exists', $_SESSION) ? $_SESSION['survey_exists'] : false;
             $paramArray["PARTICIPANT_PHOTOS"] = PARTICIPANT_PHOTOS === TRUE ? 1 : 0;
             RenderXSLT('ParticipantMenu_BS4.xsl', $paramArray, GeneratePermissionSetXML());

--- a/webpages/api/confirm_session_assignment.php
+++ b/webpages/api/confirm_session_assignment.php
@@ -2,7 +2,7 @@
 // Created by BC Holmes on 2022-03-16.
 
 if (!include ('../config/db_name.php')) {
-	include ('../config/db_name.php');
+    include ('../config/db_name.php');
 }
 
 require_once('./db_support_functions.php');
@@ -15,7 +15,7 @@ function update_participant_confirmation($db, $sessionId, $participantSessionId,
     WHERE participantonsessionid = ?
       AND sessionid = ?
       AND badgeid = ?;
- EOD;
+EOD;
 
     $stmt = mysqli_prepare($db, $query);
     mysqli_stmt_bind_param($stmt, "siis", $confirmValue, $participantSessionId, $sessionId, $badgeId);
@@ -34,7 +34,7 @@ function update_participant_confirmation_notes($db, $sessionId, $participantSess
     WHERE participantonsessionid = ?
       AND sessionid = ?
       AND badgeid = ?;
- EOD;
+EOD;
 
     $stmt = mysqli_prepare($db, $query);
     mysqli_stmt_bind_param($stmt, "siis", $notes, $participantSessionId, $sessionId, $badgeId);

--- a/webpages/api/session_feedback_list.php
+++ b/webpages/api/session_feedback_list.php
@@ -48,6 +48,7 @@ function find_session_for_feedback($db, $badgeid, $term) {
       LEFT OUTER JOIN ParticipantSessionInterest psi on psi.sessionid = s.sessionid and psi.badgeid = ?
      WHERE ss.may_be_scheduled = 1
        AND ps.pubstatusid = 2
+       AND s.divisionid in (select divisionid from Divisions where allow_partSessionInterest = 1)
        $clause
      ORDER BY t.display_order, s.sessionid;
 EOD;

--- a/webpages/api/session_feedback_list.php
+++ b/webpages/api/session_feedback_list.php
@@ -48,7 +48,7 @@ function find_session_for_feedback($db, $badgeid, $term) {
       LEFT OUTER JOIN ParticipantSessionInterest psi on psi.sessionid = s.sessionid and psi.badgeid = ?
      WHERE ss.may_be_scheduled = 1
        AND ps.pubstatusid = 2
-       AND s.divisionid in (select divisionid from Divisions where allow_partSessionInterest = 1)
+       AND s.divisionid in (select divisionid from Divisions where is_part_session_interest_allowed = 1)
        $clause
      ORDER BY t.display_order, s.sessionid;
 EOD;

--- a/webpages/xsl/ParticipantMenu_BS4.xsl
+++ b/webpages/xsl/ParticipantMenu_BS4.xsl
@@ -9,6 +9,7 @@
   <xsl:param name="survey" select="'false'" />
   <xsl:param name="my_suggestions" select="'true'" />
   <xsl:param name="SessionFeedback" select="'true'" />
+  <xsl:param name="SessionInterests" select="'true'" />
   <xsl:template match="/">
     <nav id="participantNav" class="navbar navbar-expand-lg navbar-dark bg-dark mb-3">
       <span class="navbar-brand py-1">
@@ -52,7 +53,12 @@
               <a class="nav-link py-1" href="PartSearchSessions.php">Search Sessions</a>
             </li>
           </xsl:if>
-          <xsl:if test="/doc/query[@queryname='permission_set']/row[@permatomtag='SessionFeedback']">
+          <xsl:if test="$SessionInterests">
+            <li class="nav-item py-0">
+              <a class="nav-link py-1" href="PartPanelInterests.php">Session Interests</a>
+            </li>
+          </xsl:if>
+          <xsl:if test="$SessionFeedback">
             <li class="nav-item py-0">
               <a class="nav-link py-1" href="SessionFeedback.php">Interest Survey</a>
             </li>


### PR DESCRIPTION
A few more fixes for the session feedback and the Interests pages. The old Interests page wasn't showing and if a con wants to use that, then it needs to show.
Fixed a couple of typos.
Added a new field to the Divisions table per note by BC on PR #26 - a field to identify which divisions will let participants show their interest in sessions scheduled within that division. Field: allow_partSessionInterest
Does this field name look ok?