### PR TITLE
Make config editor use first varchar column if no 'name' column

### DIFF
--- a/webpages/SubmitEditConfigTable.php
+++ b/webpages/SubmitEditConfigTable.php
@@ -224,6 +224,30 @@ EOD;
     return null;
 }
 
+/*
+ *  Return the name of the first column of type "varchar" on the table. 
+ */
+function lookupVarcharColumn($tableName)
+{
+    $db = DBDB;
+    $query = <<<EOD
+        SELECT
+            COLUMN_NAME
+        FROM
+            INFORMATION_SCHEMA.COLUMNS
+        WHERE
+            TABLE_SCHEMA = '$db'
+            AND TABLE_NAME = '$tableName'
+            AND DATA_TYPE = 'varchar';
+EOD;
+    $result = mysqli_query_exit_on_error($query);
+    if ($row = $result->fetch_object()) {
+      return $row->COLUMN_NAME;
+    }
+
+    return null;
+}
+
 function fetch_table($tablename, $message) {
     global $schema, $displayorder_found, $json_return, $prikey;
     $db = DBDB;
@@ -348,6 +372,7 @@ EOD;
         $reffield = substr($key, $periodpos + 1);
 
         $namefield = lookupNameColumn($reftable);
+        if (is_null($namefield)) $namefield = lookupVarcharColumn($reftable);
         $data = array();
         $query = "SELECT $reffield AS id, $namefield AS name FROM $reftable ORDER BY display_order;";
         $result = mysqli_query_exit_on_error($query);


### PR DESCRIPTION
Added an extra function, `lookupVarcharColumn`, to the config editor to return the first column of type "varchar" on the table.
If no column ends with "name" , `lookupNameColumn` will return null, this function gets called instead.
This should make the configuration editor more flexible, and removes the need for anyone adding a new reference table to understand that it must have a column ending in "name".