### PR TITLE
Add config files to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,8 @@ client/dist/
 webpages/brainstorm/build
 webpages/brainstorm/node_modules/
 webpages/vendor/
+
+# Exclude non-sample config files.
+webpages/config/db_name.php
+webpages/config/db_env.php
+webpages/config/db.php


### PR DESCRIPTION
A minor addition to .gitignore to exclude common config file names so developers don't accidentally check in their local config files.