### PR TITLE
Fix handling of null values in schedule_functions.

### DIFF
--- a/webpages/schedule_functions.php
+++ b/webpages/schedule_functions.php
@@ -43,29 +43,29 @@ function render_sessions_as_xml($sessions) {
 
     foreach ($sessions as $s) {
         $panel = $xml -> createElement("session");
-        $panel->setAttribute("title", $s->title);
-        $panel->setAttribute("progguiddesc", $s->progguiddesc);
-        $panel->setAttribute("roomname", $s->roomname);
-        $panel->setAttribute("trackname", $s->trackname);
-        $panel->setAttribute("hashtag", $s->hashtag);
-        $panel->setAttribute("starttime", $s->starttime);
+        $panel->setAttribute("title", isset($s->starttime) ? $s->title : '');
+        $panel->setAttribute("progguiddesc", isset($s->progguiddesc) ? $s->progguiddesc : '');
+        $panel->setAttribute("roomname", isset($s->roomname) ? $s->roomname : '');
+        $panel->setAttribute("trackname", isset($s->trackname) ? $s->trackname : '');
+        $panel->setAttribute("hashtag", isset($s->hashtag) ? $s->hashtag : '');
+        $panel->setAttribute("starttime", isset($s->starttime) ? $s->starttime : '');
         
         foreach ($s->participants as $p) {
             $particpant = $xml -> createElement("participant");
-            $particpant->setAttribute("pubsname", $p->pubsname);
-            $particpant->setAttribute("badgeid", $p->badgeid);
-            $particpant->setAttribute("moderator", $p->moderator);
-            $particpant->setAttribute("pronouns", $p->pronouns);
+            $particpant->setAttribute("pubsname", isset($p->pubsname) ? $p->pubsname : '');
+            $particpant->setAttribute("badgeid", isset($p->badgeid) ? $p->badgeid : '');
+            $particpant->setAttribute("moderator", isset($p->moderator) ? $p->moderator : '');
+            $particpant->setAttribute("pronouns", isset($p->pronouns) ? $p->pronouns : '');
 
             $panel -> appendChild($particpant);
 
             if (!is_null($p->nextSession)) {
                 $next = $xml -> createElement("nextSession");
-                $next->setAttribute("title", $p->nextSession->title);
-                $next->setAttribute("progguiddesc", $p->nextSession->progguiddesc);
-                $next->setAttribute("roomname", $p->nextSession->roomname);
-                $next->setAttribute("trackname", $p->nextSession->trackname);
-                $next->setAttribute("starttime", $p->nextSession->starttime);
+                $next->setAttribute("title", isset($p->title) ? $p->nextSession->title : '');
+                $next->setAttribute("progguiddesc", isset($p->progguiddesc) ? $p->nextSession->progguiddesc : '');
+                $next->setAttribute("roomname", isset($p->roomname) ? $p->nextSession->roomname : '');
+                $next->setAttribute("trackname", isset($p->trackname) ? $p->nextSession->trackname : '');
+                $next->setAttribute("starttime", isset($p->starttime) ? $p->nextSession->starttime : '');
                 $particpant -> appendChild($next);
             }
         }
@@ -140,10 +140,10 @@ EOD;
     while ($row = mysqli_fetch_assoc($result)) {
         $session = $sessionsById[$row["sessionid"]];
         $participant = new ScheduledParticipant();
-        $participant->pubsname = $row["pubsname"];
-        $participant->moderator = $row["moderator"];
-        $participant->badgeid = $row["badgeid"];
-        $participant->pronouns = $row["pronouns"];
+        $participant->pubsname = array_key_exists('pubsname', $row) ? $row["pubsname"] : '';
+        $participant->moderator = array_key_exists('moderator', $row) ? $row["moderator"] : '';
+        $participant->badgeid = array_key_exists('badgeid', $row) ? $row["badgeid"] : '';
+        $participant->pronouns = array_key_exists('pronouns', $row) ? $row["pronouns"] : '';
 
         $session->participants[] = $participant;
     }


### PR DESCRIPTION
I had a problem with null values in fields that weren't populated in my test database when printing table tents.
I'm not sure if this is just because fields weren't populated, or if it's due to stricter requirements in PHP8.
This change adds checks for unpopulated fields to solve the problem.