### PR TITLE
Add new options to table tents.

### DIFF
--- a/webpages/TableTents.php
+++ b/webpages/TableTents.php
@@ -9,9 +9,21 @@ $paramArray = array();
 if (defined('CON_THEME') && CON_THEME !== "") {
     $paramArray['additionalCss'] = CON_THEME;
 }
+if (array_key_exists("tent-type", $_REQUEST)) {
+    $tentType = $_REQUEST["tent-type"];
+    $paramArray['tentType'] = mb_strtolower($tentType, "utf-8");
+}
 if (array_key_exists("paper", $_REQUEST)) {
     $paper = $_REQUEST["paper"];
     $paramArray['paper'] = mb_strtolower($paper, "utf-8");
+}
+if (array_key_exists("fold-lines", $_REQUEST)) {
+    $foldLines = $_REQUEST["fold-lines"];
+    $paramArray['foldLines'] = mb_strtolower($foldLines, "utf-8");
+}
+if (array_key_exists("separator-pages", $_REQUEST)) {
+    $separatorPages = $_REQUEST["separator-pages"];
+    $paramArray['separatorPages'] = mb_strtolower($separatorPages, "utf-8");
 }
 
 RenderXSLT('TableTents.xsl', $paramArray, $xml);

--- a/webpages/css/zambia_print.css
+++ b/webpages/css/zambia_print.css
@@ -13,6 +13,10 @@
 .table-tent-body {
     margin: 0px;
 }
+.table-tent .page {
+    page-break-after: always;
+    page-break-inside: avoid;
+}
 .table-tent.paper-letter .page {
     height: 8.5in;
     width: 11in;
@@ -21,14 +25,30 @@
     height: 210mm;
     width: 297mm;
 }
+.table-tent.tent-type-fold-2 .front,
+.table-tent.tent-type-fold-2 .back {
+    height: 50%;
+}
+.table-tent.tent-type-fold-3 .front,
+.table-tent.tent-type-fold-3 .back {
+    height: 33%;
+}
+.table-tent.fold-lines-yes .front {
+    border-top: .1mm solid black;
+}
+
+.table-tent.tent-type-fold-3.fold-lines-yes .back {
+    border-bottom: .1mm solid black;
+}
+
 .table-tent .front {
     box-sizing: border-box;
-    height: 50%;
     display: flex; 
     justify-content: center;
     align-items: center;
     text-align:center; 
     font-weight: bold;
+    transform: rotate(-180deg);
     -webkit-transform: rotate(-180deg);
     -moz-transform: rotate(-180deg); 
     overflow: hidden;
@@ -36,7 +56,6 @@
 }
 .table-tent .back {
     box-sizing: border-box;
-    height: 50%;
     display: flex; 
     justify-content: center;
     align-items: center;

--- a/webpages/images/table-tent-fold3.svg
+++ b/webpages/images/table-tent-fold3.svg
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="500"
+   height="325"
+   viewBox="0 0 132.29166 85.989589"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2 (dc2aedaf03, 2022-05-15)"
+   sodipodi:docname="table-tent-fold3.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:document-units="px"
+     showgrid="false"
+     units="px"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:zoom="1.9035315"
+     inkscape:cx="246.64683"
+     inkscape:cy="158.91516"
+     inkscape:window-width="1803"
+     inkscape:window-height="1138"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer2"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
+  <defs
+     id="defs2" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Line Art">
+    <g
+       id="g265">
+      <path
+         style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;stroke:#000000;stroke-width:0.621253;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1"
+         d="M 24.324768,40.732431 125.12891,54.634066 90.074846,59.837909 9.5946038,46.923914 Z"
+         id="path236" />
+      <path
+         style="fill:#a6a6a6;fill-opacity:1;stroke:#000000;stroke-width:0.621253;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 125.07608,54.612324 92.209415,50.865881 24.301089,40.728445 V 20.012814 h 83.375001 z"
+         id="path1227" />
+      <path
+         style="fill:#f0f0f0;fill-opacity:1;stroke:#000000;stroke-width:0.621253;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 24.301089,18.910918 107.67609,20.012814 88.101083,60.342181 7.8677572,47.560197 Z"
+         id="path1229" />
+    </g>
+  </g>
+</svg>

--- a/webpages/javascript_functions.php
+++ b/webpages/javascript_functions.php
@@ -109,6 +109,9 @@ function load_internal_javascript($title, $isDataTables = false) {
             echo "<script src=\"external/tabulator-4.9.3/js/tabulator.js\"></script>\n";
             echo "<script src=\"js/EditConfigTables.js\"></script>\n";
             break;
+        case "Table Tents":
+            echo "<script src=\"js/tabletents.js\"></script>\n";
+            break;
         default:
             if ($isDataTables) {
                 echo "<script src=\"js/Reports.js\"></script>\n";

--- a/webpages/js/tabletents.js
+++ b/webpages/js/tabletents.js
@@ -1,0 +1,18 @@
+/**
+ * When page loads, add event handler to each table tent type radio button.
+ * When radio button changes, show correct picture and instruction.
+ */
+window.addEventListener("load", () => {
+    document.querySelectorAll(".tent-type").forEach((el) =>
+        el.addEventListener("change", (e) => {
+            if (e.target.value == "fold-2") {
+                document.querySelector(".fold-2").classList.remove("hidden");
+                document.querySelector(".fold-3").classList.add("hidden");
+            }
+            else {
+                document.querySelector(".fold-2").classList.add("hidden");
+                document.querySelector(".fold-3").classList.remove("hidden");
+            }
+        })
+    );
+});

--- a/webpages/js/tabletents.js
+++ b/webpages/js/tabletents.js
@@ -15,4 +15,17 @@ window.addEventListener("load", () => {
             }
         })
     );
+
+    document.querySelectorAll(".separator-pages").forEach((el) =>
+        el.addEventListener("change", (e) => {
+            if (e.target.value == "yes") {
+                document.querySelector(".separator-pages-yes").classList.remove("hidden");
+                document.querySelector(".separator-pages-no").classList.add("hidden");
+            }
+            else {
+                document.querySelector(".separator-pages-yes").classList.add("hidden");
+                document.querySelector(".separator-pages-no").classList.remove("hidden");
+            }
+        })
+    );
 });

--- a/webpages/xsl/TableTents.xsl
+++ b/webpages/xsl/TableTents.xsl
@@ -25,13 +25,21 @@
     <xsl:template match="doc/session">
         <section>
             <xsl:attribute name="class">
-                <xsl:value-of select="'table-tent paper-'" /> 
+                <xsl:value-of select="'table-tent tent-type-'" /> 
+                <xsl:value-of select="$tentType" />
+                <xsl:value-of select="' paper-'" /> 
                 <xsl:value-of select="$paper" />
+                <xsl:value-of select="' fold-lines-'" /> 
+                <xsl:value-of select="$foldLines" />
+                <xsl:value-of select="' separator-pages-'" /> 
+                <xsl:value-of select="$separatorPages" />
             </xsl:attribute>
-            <div class="page">
-                <div class="front"><h1 class="title"><xsl:value-of select="@title" disable-output-escaping="yes"/></h1></div>
-                <div class="back"><h1 class="title"><xsl:value-of select="@title" disable-output-escaping="yes"/></h1></div>
-            </div>
+            <xsl:if test="$separatorPages = 'yes'">
+                <div class="page">
+                    <div class="front"><h1 class="title"><xsl:value-of select="@title" disable-output-escaping="yes"/></h1></div>
+                    <div class="back"><h1 class="title"><xsl:value-of select="@title" disable-output-escaping="yes"/></h1></div>
+                </div>
+            </xsl:if>
             <xsl:if test="not(@hashtag = '')">
                 <div class="page">
                     <div class="front"><h1 class="title"><xsl:value-of select="@hashtag" /></h1></div>

--- a/webpages/xsl/TableTentsConfig.xsl
+++ b/webpages/xsl/TableTentsConfig.xsl
@@ -35,7 +35,7 @@
                     </div>
 
                     <div class="fold-3 hidden">
-                        <p>These tents are self supporting. Fold in 3 and display with guest name facing forwards.</p>
+                        <p>These tents are self supporting. Fold in 3 and display with participant's name facing forwards.</p>
 
                         <div class="text-center">
                             <img src="./images/table-tent-fold3.svg" style="height: 325px; width: 500px;" />
@@ -77,6 +77,12 @@
                             No
                         </label>
                     </div>
+                    <div class="separator-pages-yes">
+                        <p>A separator page will be printed before each session's table tents to help group them.</p>
+                    </div>                    
+                    <div class="separator-pages-no hidden">
+                        <p>No separator page will be printed. You will have to separate each session's tents by the session title on each tent.</p>
+                    </div>                    
                 </div>
                 <div class="card-footer">
                     <button type="submit" class="btn btn-primary">Generate</button>

--- a/webpages/xsl/TableTentsConfig.xsl
+++ b/webpages/xsl/TableTentsConfig.xsl
@@ -12,22 +12,70 @@
                     In many cons, the tents are printed out in the Green Room, and the panel moderator picks them up just before the panel 
                     is scheduled to begin.</p>
 
-                    <p>To use these, you'll need a prism-shaped stand. The stands are reusable, and can remain in a room. When a new group of
-                    session participants comes in, they can fold the tents in half and lay them over the stand, with the name portion visible to
-                    the audience.</p>
-
-                    <div class="text-center">
-                        <img src="./images/table-tent.svg" style="height: 325px; width: 500px;" />
+                    <div class="row">
+                        <label class="col-md-3">Type of table tent:</label>
+                        <label class="radio col-md-2">
+                            <input type="radio" id="fold-2" class="tent-type" name="tent-type" value="fold-2" checked="checked" />
+                            Fold in 2
+                        </label>
+                        <label class="radio col-md-2">
+                            <input type="radio" id="fold-3" class="tent-type" name="tent-type" value="fold-3" />
+                            Fold in 3
+                        </label>
                     </div>
 
-                    <div class="row">
-                        <div class="form-group col-md-6">
+                    <div class="fold-2">
+                        <p>To use these, you'll need a prism-shaped stand. The stands are reusable, and can remain in a room. When a new group of
+                        session participants comes in, they can fold the tents in half and lay them over the stand, with the name portion visible to
+                        the audience.</p>
+
+                        <div class="text-center">
+                            <img src="./images/table-tent.svg" style="height: 325px; width: 500px;" />
+                        </div>
+                    </div>
+
+                    <div class="fold-3 hidden">
+                        <p>These tents are self supporting. Fold in 3 and display with guest name facing forwards.</p>
+
+                        <div class="text-center">
+                            <img src="./images/table-tent-fold3.svg" style="height: 325px; width: 500px;" />
+                        </div>
+                    </div>
+
+                    <div class="row form-group">
+                        <div class="col-md-3">
                             <label for="paper">Paper type:</label>
+                        </div>
+                        <div class="col-md-4">
                             <select id="paper" name="paper" class="form-control">
                                 <option value="LETTER">Letter-sized</option>
                                 <option value="A4">A4-sized</option>
                             </select>
                         </div>
+                    </div>
+
+                    <div class="row">
+                        <label class="col-md-3">Print fold lines:</label>
+                        <label class="radio col-md-1">
+                            <input type="radio" id="fold-yes" class="fold-lines" name="fold-lines" value="yes" checked="checked" />
+                            Yes
+                        </label>
+                        <label class="radio col-md-1">
+                            <input type="radio" id="fold-no" class="fold-lines" name="fold-lines" value="no" />
+                            No
+                        </label>
+                    </div>
+
+                    <div class="row">
+                        <label class="col-md-3">Print separator pages:</label>
+                        <label class="radio col-md-1">
+                            <input type="radio" id="separator-yes" class="separator-pages" name="separator-pages" value="yes" checked="checked" />
+                            Yes
+                        </label>
+                        <label class="radio col-md-1">
+                            <input type="radio" id="separator-no" class="separator-pages" name="separator-pages" value="no" />
+                            No
+                        </label>
                     </div>
                 </div>
                 <div class="card-footer">


### PR DESCRIPTION
Adds several new options for generating table tents:
- Table tent type - this selects whether table tents are folded in 2 (as present) or folded in 3. Javascript changes the picture when selection changed.
- Page size - unchanged.
- Print fold lines - if selected, guide lines for folding are printed.
- Print separator pages - determines whether a separator page is printed before each session. If "yes", a page with the session title is printed. If "No", only the table tents are printed.

Also added some CSS `page-break-after` and `page-break-inside` settings to keep table tents aligned with pages, as I was finding they would sometimes get out of step, especially on Chrome.

Additional commit to make descriptions clearer:
- Changed "guest's name" to "participant's name".
- Added description below Print Separator Pages field.