### PR TITLE
Treat the auto-scheduler as a module

### DIFF
--- a/Install/Upgrade_dbase/84ZED_autoscheduler_as_module.sql
+++ b/Install/Upgrade_dbase/84ZED_autoscheduler_as_module.sql
@@ -1,0 +1,22 @@
+## 
+## Treat the autoscheduler as a module
+##
+## Created by BC Holmes
+##
+
+INSERT INTO `module` 
+(`name`, `package_name`, `description`, `is_enabled`)
+values 
+('Auto-Scheduler', 'planz.autoscheduler', 
+'The auto-scheduler attempts to find the optimal schedule using participants'' availability, room sizes, and other data.', 0);
+
+insert into `PermissionAtoms` (permatomtag, page, notes)
+values ('AutoScheduler', 'Auto Scheduler', 'Allows the programming team to run the auto-scheduler');
+
+# Give the admin role autoscheduler privileges
+insert into `Permissions` (permatomid, phaseid, permroleid)
+select max(permatomid), null, 1 from PermissionAtoms;
+
+UPDATE `PermissionAtoms` SET module_id = (select max(id) from `module`) WHERE `permatomtag` in ('AutoScheduler');
+
+INSERT INTO PatchLog (patchname) VALUES ('84ZED_autoscheduler_as_module.sql');

--- a/webpages/StaffHeader.php
+++ b/webpages/StaffHeader.php
@@ -47,7 +47,6 @@ function staff_header($title, $bootstrap4 = false, $is_report = false, $reportCo
             $paramArray["badgename"] = $_SESSION['badgename'];
         }
         $paramArray["PARTICIPANT_PHOTOS"] = PARTICIPANT_PHOTOS === TRUE ? 1 : 0;
-        $paramArray["AUTO_SCHEDULER"] = AUTO_SCHEDULER === TRUE ? 1 : 0;
         $paramArray["emailAvailable"] = SMTP_ADDRESS == '' ? 0 : 1;
         $paramArray["isToolbarPresent"] = $isToolbarPresent ? 1 : 0;
         try {

--- a/webpages/config/db_name_sample.php
+++ b/webpages/config/db_name_sample.php
@@ -105,8 +105,6 @@ define("CON_SUPPORT_EMAIL", ""); // From address to be used for password reset e
 
 define("REPORT_INCLUDE_DIRECTORY", "/var/data/planz/");  // outside of web server path, only served by PHP
 
-define("AUTO_SCHEDULER", FALSE); // enable the auto-scheduler feature
-
 define("PUBLIC_NEW_USER", FALSE); // allow new user creation from login screen
 
 define("CONFIRM_SESSION_ASSIGNMENT", TRUE); // Ask participants to confirm their assignments

--- a/webpages/xsl/StaffMenu.xsl
+++ b/webpages/xsl/StaffMenu.xsl
@@ -8,7 +8,6 @@
   <!-- Page title -->
   <xsl:param name="reportMenuList" select="''"/>
   <xsl:param name="PARTICIPANT_PHOTOS" select="'0'"/>
-  <xsl:param name="AUTO_SCHEDULER" select="'0'"/>
   <xsl:param name="emailAvailable" select="'0'"/>
   <!-- Set of <li> elements; contents of ReportMenuInclude.php -->
   <xsl:variable name="ConfigureReports" select="/doc/query[@queryname='permission_set']/row[@permatomtag='ConfigureReports']"/>
@@ -25,6 +24,7 @@
         @permatomtag='ce_RegTypes' or @permatomtag='ce_Roles' or @permatomtag='ce_RoomColors' or @permatomtag='ce_Rooms' or @permatomtag='ce_RoomSets' or
         @permatomtag='ce_RoomHasSet' or @permatomtag='ce_Services' or @permatomtag='ce_ServiceTypes' or @permatomtag='ce_SessionStatuses' or
         @permatomtag='ce_Tags' or @permatomtag='ce_Times' or @permatomtag='ce_Tracks' or @permatomtag='ce_Types']"/>
+  <xsl:variable name="AutoScheduler" select="/doc/query[@queryname='permission_set']/row[@permatomtag='AutoScheduler']"/>
   <xsl:template match="/">
     <nav id="staffNav" class="navbar navbar-inverse">
       <div class="navbar-inner">
@@ -131,7 +131,7 @@
                   <b class="caret"/>
                 </a>
                 <ul class="dropdown-menu">
-                  <xsl:if test="$AUTO_SCHEDULER = '1'">
+                  <xsl:if test="$AutoScheduler">
                     <li>
                       <a href="Autoscheduler.php">Auto-Scheduler</a>
                     </li>

--- a/webpages/xsl/StaffMenu_BS4.xsl
+++ b/webpages/xsl/StaffMenu_BS4.xsl
@@ -9,7 +9,6 @@
     <xsl:param name="reportMenuList" select="''"/>
     <xsl:param name="badgename" select="'Current User'"/>
     <xsl:param name="PARTICIPANT_PHOTOS" select="'0'"/>
-    <xsl:param name="AUTO_SCHEDULER" select="'0'"/>
     <xsl:param name="emailAvailable" select="'0'"/>
     <xsl:param name="isToolbarPresent" select="'0'"/>
     <!-- Set of <a> elements; contents of ReportMenuBS4Include.php -->
@@ -29,6 +28,7 @@
         @permatomtag='ce_RegTypes' or @permatomtag='ce_Roles' or @permatomtag='ce_RoomColors' or @permatomtag='ce_Rooms' or @permatomtag='ce_RoomSets' or
         @permatomtag='ce_RoomHasSet' or @permatomtag='ce_Services' or @permatomtag='ce_ServiceTypes' or @permatomtag='ce_SessionStatuses' or
         @permatomtag='ce_Tags' or @permatomtag='ce_Times' or @permatomtag='ce_Tracks' or @permatomtag='ce_Types']"/>
+    <xsl:variable name="AutoScheduler" select="/doc/query[@queryname='permission_set']/row[@permatomtag='AutoScheduler']"/>
     <xsl:template match="/">
         <nav id="staffNav">
             <xsl:choose>
@@ -117,7 +117,7 @@
                             Scheduling
                         </a>
                         <div class="dropdown-menu" aria-labelledby="navbarSchedulingDropdown">
-                            <xsl:if test="$AUTO_SCHEDULER = '1'">
+                            <xsl:if test="$AutoScheduler">
                                 <a class="dropdown-item" href="Autoscheduler.php">Auto-Scheduler</a>
                             </xsl:if>
                             <a class="dropdown-item" href="MaintainRoomSched.php">Maintain Room Schedule</a>


### PR DESCRIPTION
Treat the auto-scheduler as a separate module which can be activated/deactivated by the admin page, rather than use a deploy-time configuration file.