### PR TITLE
Add min and max session title length to configuration.

### DIFF
--- a/webpages/RenderEditCreateSession.php
+++ b/webpages/RenderEditCreateSession.php
@@ -89,7 +89,7 @@ function RenderEditCreateSession ($action, $session, $message1, $message2) {
         <div class="row">
             <div class="form-group col-md-5 offset-md-1">
                 <label for="title">Title:</label>
-                <input type="text" class="form-control" size="50" name="title" value="<?php echo htmlspecialchars($session["title"],ENT_COMPAT);?>" />&nbsp;&nbsp;
+                <input type="text" class="form-control" size="<?php echo TITLE_MAX_LENGTH; ?>" name="title" value="<?php echo htmlspecialchars($session["title"],ENT_COMPAT);?>" />&nbsp;&nbsp;
             </div>
             <div class="col-md-2 pt-3">
                 <div class="form-check ">
@@ -114,7 +114,7 @@ function RenderEditCreateSession ($action, $session, $message1, $message2) {
     <div class="row">
         <div class="form-group col-md-5 offset-md-1">
             <label for="secondtitle"><?php echo SECOND_TITLE_CAPTION;?></label>
-            <input type="text" size="50" class="form-control" name="secondtitle" value="<?php echo htmlspecialchars($session["secondtitle"],ENT_COMPAT);?>" />
+            <input type="text" size="<?php echo TITLE_MAX_LENGTH; ?>" class="form-control" name="secondtitle" value="<?php echo htmlspecialchars($session["secondtitle"],ENT_COMPAT);?>" />
         </div>
         <div class="form-group col-md-5 offset-md-1">
             <label for="languagestatusid">Session Language: </label>

--- a/webpages/RenderEditCreateSession.php
+++ b/webpages/RenderEditCreateSession.php
@@ -89,7 +89,7 @@ function RenderEditCreateSession ($action, $session, $message1, $message2) {
         <div class="row">
             <div class="form-group col-md-5 offset-md-1">
                 <label for="title">Title:</label>
-                <input type="text" class="form-control" size="<?php echo TITLE_MAX_LENGTH; ?>" name="title" value="<?php echo htmlspecialchars($session["title"],ENT_COMPAT);?>" />&nbsp;&nbsp;
+                <input type="text" class="form-control" size="50" maxlength="<?php echo TITLE_MAX_LENGTH; ?>" name="title" value="<?php echo htmlspecialchars($session["title"],ENT_COMPAT);?>" />&nbsp;&nbsp;
             </div>
             <div class="col-md-2 pt-3">
                 <div class="form-check ">
@@ -114,7 +114,7 @@ function RenderEditCreateSession ($action, $session, $message1, $message2) {
     <div class="row">
         <div class="form-group col-md-5 offset-md-1">
             <label for="secondtitle"><?php echo SECOND_TITLE_CAPTION;?></label>
-            <input type="text" size="<?php echo TITLE_MAX_LENGTH; ?>" class="form-control" name="secondtitle" value="<?php echo htmlspecialchars($session["secondtitle"],ENT_COMPAT);?>" />
+            <input type="text" size="50" maxlength="<?php echo TITLE_MAX_LENGTH; ?>" class="form-control" name="secondtitle" value="<?php echo htmlspecialchars($session["secondtitle"],ENT_COMPAT);?>" />
         </div>
         <div class="form-group col-md-5 offset-md-1">
             <label for="languagestatusid">Session Language: </label>

--- a/webpages/config/db_name_sample.php
+++ b/webpages/config/db_name_sample.php
@@ -39,6 +39,8 @@ define("MY_AVAIL_KIDS", FALSE); // Enables questions regarding no. of kids in Fa
 define("ENABLE_SHARE_EMAIL_QUESTION", TRUE); // Enables question regarding sharing participant email address
 define("ENABLE_USE_PHOTO_QUESTION", TRUE); // Enables question regarding using participant photo for promotional purposes
 define("ENABLE_BESTWAY_QUESTION", FALSE); // Enables question regarding best way to contact participant
+define("TITLE_MIN_LENGTH", 10); // Title must be at least this long.
+define("TITLE_MAX_LENGTH", 50); // Title must not be longer than this. Note that the current limit of the DB field is 100 characters.
 define("BILINGUAL", TRUE); // Triggers extra fields in Session and "My General Interests"
 define("SECOND_LANG", "FRENCH");
 define("SECOND_TITLE_CAPTION", "Titre en fran&ccedil;ais");

--- a/webpages/validation_functions.php
+++ b/webpages/validation_functions.php
@@ -174,8 +174,8 @@ function validate_session() {
         return ($flag);
     }
     $i = mb_strlen($session["title"]);
-    if ($i < 10 || $i > 48) {
-        $messages .= "Title is $i characters long.  Please edit it to between <b>10</b> and <b>48</b> characters.<br>\n";
+    if ($i < TITLE_MIN_LENGTH || $i > TITLE_MAX_LENGTH) {
+        $messages .= "Title is $i characters long.  Please edit it to between <b>" . TITLE_MIN_LENGTH . "</b> and <b>" . TITLE_MAX_LENGTH . "</b> characters.<br>\n";
         $flag = false;
     }
     $i = mb_strlen($session["progguiddesc"]);


### PR DESCRIPTION
- Define `TITLE_MIN_LENGTH` and `TITLE_MAX_LENGTH` settings in `db_name.php`
- Set `maxlength` to `TITLE_MAX_LENGTH` in `RenderEditCreateSession`
- Check title length between `TITLE_MIN_LENGTH` and `TITLE_MAX_LENGTH` in `validate_session()`