### PR TITLE
Add number of digits to pad user ID numbers with.

### DIFF
--- a/webpages/AddUser.php
+++ b/webpages/AddUser.php
@@ -178,11 +178,11 @@ while ($row = mysqli_fetch_assoc($result)) {
 }
 mysqli_free_result($result);
 if ($last_badgeid == "") {
-    $last_badgeid = REG_PART_PREFIX . "1000";
+    $last_badgeid = REG_PART_PREFIX . "0";
 }
 
 $id = mb_substr($last_badgeid, mb_strlen(REG_PART_PREFIX));
-$new_badgeid = REG_PART_PREFIX . strval(intval($id) + 1);
+$new_badgeid = REG_PART_PREFIX . str_pad(strval(intval($id) + 1), REG_PART_DIGITS, '0', STR_PAD_LEFT);
 
 $PriorArray["new_badgeid"] = $new_badgeid;
 

--- a/webpages/config/db_name_sample.php
+++ b/webpages/config/db_name_sample.php
@@ -76,6 +76,7 @@ define("USE_REG_SYSTEM", FALSE);
 define("REGISTRATION_URL", "");
 define("USE_PRONOUNS", TRUE); // let participants specify their pronouns
 define("REG_PART_PREFIX", ""); // only needed for USE_REG_SYSTEM = FALSE; prefix portion of userid/badgeid before counter; can be empty string for no prefix
+define("REG_PART_DIGITS", 4); // only needed for USE_REG_SYSTEM = FALSE; number of digits to pad counter; if number has fewer than specified digits, will left pad with zeros
 define("HTML_BIO", TRUE); // Allow editing BIO as HTML and saving it both as plain text and HTML
 define("HTML_SESSION", TRUE); // Allow editing Session Description as HTML and saving it both as plain text and HTML
 define("MEETING_LINK", TRUE); // Add support for Meetinglink in sessions


### PR DESCRIPTION
A convention I'm involved has a tradition of a lot of people joining late, so need to be able to manually add participants who haven't registered yet. I'm using different prefixes for reg system and manual members, but I want to pad the manual member badge IDs to be padded to 4 decimal places.