### PR TITLE
Display RegType.message for member registration

### DIFF
--- a/webpages/SubmitAdminParticipants.php
+++ b/webpages/SubmitAdminParticipants.php
@@ -17,6 +17,7 @@ function fetch_participant() {
         RenderErrorAjax($message_error);
         exit();
     }
+
     $query = <<<EOD
 SELECT
     P.badgeid,
@@ -306,7 +307,9 @@ function perform_search() {
     if ($searchString == "")
         exit();
     $json_return = array ();
-    if (is_numeric($searchString)) {
+    $regTypeField = USE_REGTYPE_DESCRIPTION ? "COALESCE(RT.message, CD.regtype) AS regtype" : "CD.regtype";
+
+    if (is_numeric($searchString)) {    
         if (DBVER >= "8") {
             $query = <<<EOD
 WITH AnsweredSurvey(participantid, answercount) AS (
@@ -318,7 +321,7 @@ SELECT
     P.badgeid, P.pubsname, P.sortedpubsname, P.interested, P.bio, P.htmlbio,
     P.staff_notes, CD.firstname, CD.lastname, CD.badgename,
     CD.phone, CD.email, CD.postaddress1, CD.postaddress2, CD.postcity, CD.poststate, CD.postzip,
-    CD.postcountry, CD.regtype, IFNULL(A.answercount, 0) AS answercount,
+    CD.postcountry, $regTypeField, IFNULL(A.answercount, 0) AS answercount,
     P.uploadedphotofilename, P.approvedphotofilename, P.photodenialreasonothertext,
     CASE WHEN ISNULL(P.photouploadstatus) THEN 0 ELSE P.photouploadstatus END AS photouploadstatus,
     R.statustext, D.reasontext
@@ -328,6 +331,7 @@ FROM
     LEFT OUTER JOIN AnsweredSurvey A ON (P.badgeid = A.participantid)
     LEFT OUTER JOIN PhotoDenialReasons D USING (photodenialreasonid)
     LEFT OUTER JOIN PhotoUploadStatus R USING (photouploadstatus)
+    LEFT OUTER JOIN RegTypes RT USING (regtype)
 WHERE
     P.badgeid = ?
 ORDER BY
@@ -339,7 +343,7 @@ SELECT
     P.badgeid, P.pubsname, P.sortedpubsname, P.interested, P.bio, P.htmlbio,
     P.staff_notes, CD.firstname, CD.lastname, CD.badgename,
     CD.phone, CD.email, CD.postaddress1, CD.postaddress2, CD.postcity, CD.poststate, CD.postzip,
-    CD.postcountry, CD.regtype, IFNULL(A.answercount, 0) AS answercount,
+    CD.postcountry, $regTypeField, IFNULL(A.answercount, 0) AS answercount,
     P.uploadedphotofilename, P.approvedphotofilename, P.photodenialreasonothertext,
     CASE WHEN ISNULL(P.photouploadstatus) THEN 0 ELSE P.photouploadstatus END AS photouploadstatus,
     R.statustext, D.reasontext
@@ -353,6 +357,7 @@ FROM
     ) A ON (P.badgeid = A.participantid)
 LEFT OUTER JOIN PhotoDenialReasons D USING (photodenialreasonid)
 LEFT OUTER JOIN PhotoUploadStatus R USING (photouploadstatus)
+LEFT OUTER JOIN RegTypes RT USING (regtype)
 WHERE
     P.badgeid = ?
 ORDER BY
@@ -373,7 +378,7 @@ SELECT
     P.badgeid, P.pubsname, P.sortedpubsname, P.interested, P.bio, P.htmlbio,
     P.staff_notes, CD.firstname, CD.lastname, CD.badgename,
     CD.phone, CD.email, CD.postaddress1, CD.postaddress2, CD.postcity, CD.poststate, CD.postzip,
-    CD.postcountry, CD.regtype, IFNULL(A.answercount, 0) AS answercount,
+    CD.postcountry, $regTypeField, IFNULL(A.answercount, 0) AS answercount,
     P.uploadedphotofilename, P.approvedphotofilename, P.photodenialreasonothertext,
     CASE WHEN ISNULL(P.photouploadstatus) THEN 0 ELSE P.photouploadstatus END AS photouploadstatus,
     R.statustext, D.reasontext
@@ -383,6 +388,7 @@ FROM
     LEFT OUTER JOIN AnsweredSurvey A ON (P.badgeid = A.participantid)
     LEFT OUTER JOIN PhotoDenialReasons D USING (photodenialreasonid)
     LEFT OUTER JOIN PhotoUploadStatus R USING (photouploadstatus)
+    LEFT OUTER JOIN RegTypes RT USING (regtype)
 WHERE
         P.pubsname LIKE ?
     OR CD.lastname LIKE ?
@@ -397,7 +403,7 @@ SELECT
     P.badgeid, P.pubsname, P.sortedpubsname, P.interested, P.bio, P.htmlbio,
     P.staff_notes, CD.firstname, CD.lastname, CD.badgename,
     CD.phone, CD.email, CD.postaddress1, CD.postaddress2, CD.postcity, CD.poststate, CD.postzip,
-    CD.postcountry, CD.regtype, IFNULL(A.answercount, 0) AS answercount,
+    CD.postcountry, $regTypeField, IFNULL(A.answercount, 0) AS answercount,
     P.uploadedphotofilename, P.approvedphotofilename, P.photodenialreasonothertext,
     CASE WHEN ISNULL(P.photouploadstatus) THEN 0 ELSE P.photouploadstatus END AS photouploadstatus,
     R.statustext, D.reasontext
@@ -411,6 +417,7 @@ FROM
     ) A ON (P.badgeid = A.participantid)
     LEFT OUTER JOIN PhotoDenialReasons D USING (photodenialreasonid)
     LEFT OUTER JOIN PhotoUploadStatus R USING (photouploadstatus)
+    LEFT OUTER JOIN RegTypes RT USING (regtype)
 WHERE
         P.pubsname LIKE ?
     OR CD.lastname LIKE ?

--- a/webpages/config/db_name_sample.php
+++ b/webpages/config/db_name_sample.php
@@ -74,6 +74,9 @@ define("USE_REG_SYSTEM", FALSE);
         // True -> PlanZ users loaded from reg system into CongoDump; staff users cannot edit them
         // False -> PlanZ users can be created and edited by staff users in PlanZ
 define("REGISTRATION_URL", "");
+define("USE_REGTYPE_DESCRIPTION", FALSE);
+        // False -> Display regtype field as registration type - name of registration type in regtype.
+        // True -> Display RegTypes.message - registration type code in regtype, description in message field.
 define("USE_PRONOUNS", TRUE); // let participants specify their pronouns
 define("REG_PART_PREFIX", ""); // only needed for USE_REG_SYSTEM = FALSE; prefix portion of userid/badgeid before counter; can be empty string for no prefix
 define("HTML_BIO", TRUE); // Allow editing BIO as HTML and saving it both as plain text and HTML

--- a/webpages/my_contact.php
+++ b/webpages/my_contact.php
@@ -4,11 +4,12 @@ global $participant, $message, $message_error, $message2, $congoinfo, $title;
 $title="My Profile";
 require ('PartCommonCode.php'); // initialize db; check login;
 //                                  set $badgeid from session
+$regTypeField = USE_REGTYPE_DESCRIPTION ? "COALESCE(RT.message, CD.regtype) AS regtype" : "CD.regtype";
 $queryArray["participant_info"] = <<<EOD
 SELECT
         CD.badgeid, CD.firstname, CD.lastname, CD.badgename, CD.phone, CD.email,
         CD.postaddress1, CD.postaddress2, CD.postcity, CD.poststate, CD.postzip,
-        CD.postcountry, CD.regtype, P.pubsname, P.sortedpubsname, P.password, P.bestway, P.interested, P.bio,
+        CD.postcountry, $regTypeField, P.pubsname, P.sortedpubsname, P.password, P.bestway, P.interested, P.bio,
         P.htmlbio, P.share_email, P.use_photo, PRO.pronounname, P.approvedphotofilename,
         P.anonymous
     FROM
@@ -16,6 +17,7 @@ SELECT
        JOIN Participants P USING (badgeid)
        LEFT JOIN ParticipantDetails PD USING (badgeid)
        LEFT JOIN Pronouns PRO USING (pronounid)
+       LEFT JOIN RegTypes RT USING (regtype)
     WHERE
         CD.badgeid=?;
 EOD;


### PR DESCRIPTION
This change is to allow a registration code to be placed in regtype, and the full description to be in RegTypes.
If USE_REGTYPE_DESCRIPTION is false, the regtype will be used (the previous behaviour).
If USE_REGTYPE_DESCRIPTION is true, the regtype will be used as a lookup code into the RegTypes table, and RegTypes.message will be displayed.