### PR TITLE
Initial changes to allow time display in 24 hour clock.

### DIFF
--- a/webpages/MaintainRoomSched.php
+++ b/webpages/MaintainRoomSched.php
@@ -247,6 +247,15 @@ while ($bigarray[$i] = mysqli_fetch_array($result, MYSQLI_ASSOC)) {
 }
 mysqli_free_result($result);
 $numsessions = --$i;
+// Build array containing hours in advance.
+$hours = [-1 => 'Hour&nbsp;'];
+if (DISPLAY_24_HOUR_TIME) {
+    foreach(array_fill(0, 24, '') as $hour => $empty) $hours[$hour] = ($hour < 10 ? '0' : '') . $hour;
+}
+else {
+    foreach(array_fill(0, 12, '') as $hour => $empty) $hours[$hour] = $hour == 0 ? '12' : $hour;
+}
+// Loop through room slots to build table rows.
 for ($i = 1; $i <= newroomslots; $i++) {
     echo "   <tr>\n";
     echo "      <td>";
@@ -266,21 +275,11 @@ for ($i = 1; $i <= newroomslots; $i++) {
         echo "</Select>&nbsp;\n";
         }
 	// ****HOUR****
-    echo "          <select class=\"span1 myspan1\" name=\"hour$i\"><option value=\"-1\" ";
-    if (!isset($_POST["hour$i"]))
-        $_POST["hour$i"]=-1;
-    if ($_POST["hour$i"]==-1)
-        echo "selected";
-    echo ">Hour&nbsp;</option><option value=0 ";
-	if ($_POST["hour$i"]==0)
-	    echo "selected";
-	echo ">12</option>";
-    for ($j=1;$j<=11;$j++) {
-        echo "<option value=$j ";
-        if ($_POST["hour$i"]==$j)
-            echo "selected";
-        echo ">$j</option>";
-        }
+    echo "          <select class=\"span1 myspan1\" name=\"hour$i\">";
+    $selectedHour = $_POST["hour$i"] ?: -1;
+    foreach ($hours as $key => $label) {
+        echo "<option value=\"${key}\" " . ($selectedHour == $key ? 'selected' : '') . ">${label}</option>";
+    }
     echo "</select>\n";
 	// ****MIN****
     echo "          <select class=\"span1 myspan1\" name=\"min$i\"><option value=\"-1\" ";
@@ -296,15 +295,17 @@ for ($i = 1; $i <= newroomslots; $i++) {
 		echo ">".($j<10?"0":"").$j."</option>";
         }
     echo "</select>\n";
-	// ****AM/PM****
-    echo "          <Select class=\"span1 myspan1\" name=\"ampm$i\"><option value=0 ";
-    if ((!isset($_POST["ampm$i"])) or $_POST["ampm$i"]==0)
-        echo "selected";
-    echo ">AM&nbsp;</option><option value=1 ";
-    if (isset($_POST["ampm$i"]) && $_POST["ampm$i"]==1)
-        echo "selected";
-	echo ">PM</option>";
-    echo "</select>\n";
+	// ****AM/PM**** - Only display if not using 24 hour time.
+    if (!DISPLAY_24_HOUR_TIME) {
+        echo "          <Select class=\"span1 myspan1\" name=\"ampm$i\"><option value=0 ";
+        if ((!isset($_POST["ampm$i"])) or $_POST["ampm$i"]==0)
+            echo "selected";
+        echo ">AM&nbsp;</option><option value=1 ";
+        if (isset($_POST["ampm$i"]) && $_POST["ampm$i"]==1)
+            echo "selected";
+        echo ">PM</option>";
+        echo "</select>\n";
+    }
     echo "          </td>";
     // ****Session****
     echo "      <td class=\"room-select-td\"><Select class=\"span8\" name=\"sess$i\"><option value=\"unset\" ";

--- a/webpages/MySchedule.php
+++ b/webpages/MySchedule.php
@@ -12,6 +12,11 @@ if (!may_I('my_schedule')) {
     RenderError($message_error);
     exit();
 }
+// Time format for displaying scheduled items.
+if (DISPLAY_24_HOUR_TIME)
+    $timeFormat = '%H:%i';
+else
+    $timeFormat = '%l:%i %p';
 // set $badgeid from session
 $queryArr = array();
 $queryArr["sessions"] = <<<EOD
@@ -22,8 +27,8 @@ SELECT
             R.roomname,
             S.progguiddesc,
             TY.typename,
-            DATE_FORMAT(ADDTIME('$CON_START_DATIM', SCH.starttime),'%a %l:%i %p') AS starttime,
-            DATE_FORMAT(ADDTIME('$CON_START_DATIM', ADDTIME(SCH.starttime, S.duration)),'%l:%i %p') AS endtime,
+            DATE_FORMAT(ADDTIME('$CON_START_DATIM', SCH.starttime),'%a $timeFormat') AS starttime,
+            DATE_FORMAT(ADDTIME('$CON_START_DATIM', ADDTIME(SCH.starttime, S.duration)),'$timeFormat') AS endtime,
             left(S.duration, 5) AS duration,
             S.persppartinfo,
             S.notesforpart

--- a/webpages/SubmitMaintainRoom.php
+++ b/webpages/SubmitMaintainRoom.php
@@ -275,8 +275,8 @@ function SubmitMaintainRoom($ignore_conflicts)
             $incompleteRows++;
             continue;
         }
-        // starttimes in minutes from start of con
-        $addToScheduleArray[$_POST["sess$i"]] = ($day - 1) * 1440 + $_POST["ampm$i"] * 720 + $_POST["hour$i"] * 60 + $_POST["min$i"];
+        // starttimes in minutes from start of con (allow for missing ampm if using 12 hours)
+        $addToScheduleArray[$_POST["sess$i"]] = ($day - 1) * 1440 + ($_POST["ampm$i"] ?: 0) * 720 + $_POST["hour$i"] * 60 + $_POST["min$i"];
         $completeRows++;
     }
     if (!$ignore_conflicts) {

--- a/webpages/api/admin/module_model.php
+++ b/webpages/api/admin/module_model.php
@@ -73,7 +73,7 @@ EOD;
             $resultSet = mysqli_stmt_get_result($stmt);
             while ($row = mysqli_fetch_object($resultSet)) {
                 $record = new PlanzModule($row->id, $row->name, $row->package_name, $row->description, $row->is_enabled);
-                $result[] = $record;
+                $result[$row->id] = $record;
             }
             mysqli_stmt_close($stmt);
             return $result;

--- a/webpages/api/admin/module_model.php
+++ b/webpages/api/admin/module_model.php
@@ -73,7 +73,7 @@ EOD;
             $resultSet = mysqli_stmt_get_result($stmt);
             while ($row = mysqli_fetch_object($resultSet)) {
                 $record = new PlanzModule($row->id, $row->name, $row->package_name, $row->description, $row->is_enabled);
-                $result[$row->id] = $record;
+                $result[] = $record;
             }
             mysqli_stmt_close($stmt);
             return $result;

--- a/webpages/config/db_name_sample.php
+++ b/webpages/config/db_name_sample.php
@@ -27,6 +27,7 @@ define("OTHER_DAY_START_TIME", "8:30");
 define("LAST_DAY_STOP_TIME", "16:00");
 define("STANDARD_BLOCK_LENGTH", "1:30"); // "1:00" and "1:30" are only values supported
         // Block includes length of panel plus time to get to next panel, e.g. 55 min plus 5 min.
+define("DISPLAY_24_HOUR_TIME", FALSE); // TRUE: times in 24 hour clock. FALSE: times in 12 hour clock.
 define("DURATION_IN_MINUTES", FALSE); // TRUE: in mmm; FALSE: in hh:mm
         // affects session edit/create page only, not reports
 define("DEFAULT_DURATION", "1:15"); // must correspond to DURATION_IN_MINUTES

--- a/webpages/data_functions.php
+++ b/webpages/data_functions.php
@@ -321,6 +321,8 @@ function time_description($time) {
     if ($netdatetime === false) {
         return false;
     }
+    if (DISPLAY_24_HOUR_TIME)
+        return date_format($netdatetime, "D H:i");
     return date_format($netdatetime, "D g:i A");
 }
 
@@ -342,6 +344,8 @@ function timeDescFromUnits($timeUnits) {
     if ($netdatetime === false) {
         return false;
     }
+    if (DISPLAY_24_HOUR_TIME)
+        return date_format($netdatetime, "D H:i");
     return date_format($netdatetime, "D g:i A");
 }
 

--- a/webpages/staffMaintainScheduleSubmit.php
+++ b/webpages/staffMaintainScheduleSubmit.php
@@ -316,18 +316,23 @@ EOD;
                 $titleStr = $dayName . " overnight into " . $nextDayName;
             }
             if ($nowMin == 0) {
-                if ($nowHour % 24 == 0) {
-                    $htmlTimesArray[$mykey]["html"] = "<td class=\"timeTop\" style=\"height:{$standardRowHeight}px\" title=\"$titleStr\" mode=\"$modeIndex\">12:00a</td>";
-                } else if ($nowHour % 24 < 12) {
-                    $htmlTimesArray[$mykey]["html"] = "<td class=\"timeTop\" style=\"height:{$standardRowHeight}px\" title=\"$titleStr\" mode=\"$modeIndex\">" . ($nowHour % 24) . ":00a</td>";
-                } else if ($nowHour % 24 == 12) {
-                    $htmlTimesArray[$mykey]["html"] = "<td class=\"timeTop\" style=\"height:{$standardRowHeight}px\" title=\"$titleStr\" mode=\"$modeIndex\">12:00p</td>";
-                } else {
-                    $htmlTimesArray[$mykey]["html"] = "<td class=\"timeTop\" style=\"height:{$standardRowHeight}px\" title=\"$titleStr\" mode=\"$modeIndex\">" . (($nowHour % 24) - 12) . ":00p</td>";
+                $class = "timeTop";
+                if (DISPLAY_24_HOUR_TIME) {
+                    $displayTime = ($nowHour % 24) . ':00';
+                }
+                else {
+                    // ToDo: This could be a good candidate for PHP 8.0's new match() statement.
+                    $displayTime =
+                        (($nowHour % 24 == 0) ? '12:00a' :
+                        (($nowHour % 24 < 12) ? ($nowHour % 24) . ':00a' :
+                        (($nowHour % 24 == 12) ? '12:00p' :
+                        (($nowHour % 24) - 12) . ':00p')));
                 }
             } else {
-                $htmlTimesArray[$mykey]["html"] = "<td class=\"timeBottom\" style=\"height:{$standardRowHeight}px\" title=\"$titleStr\" mode=\"$modeIndex\">&nbsp;</td>";
+                $class = "timeBottom";
+                $displayTime = '&nbsp;';
             }
+            $htmlTimesArray[$mykey]["html"] = "<td class=\"${class}\" style=\"height:{$standardRowHeight}px\" title=\"$titleStr\" mode=\"$modeIndex\">${displayTime}</td>";
             $nowInUnits++;
             $modeIndex++;
         }


### PR DESCRIPTION
Change "Maintain Room Schedule" and "Grid Scheduler" to display time in 24 hour clock if new `DISPLAY_24_HOUR_TIME` setting is TRUE.

In "Maintain Room Schedule", if `DISPLAY_24_HOUR_TIME` is on, the hour drop-down contains 00:00 to 23:00, and the AM/PM drop-down isn't displayed at all.

I haven't looked at time display outside of the scheduling, but I've updated some general date display functions, so anywhere using them should be caught. I suspect there will be at least one more pull request to pick up dates displayed using other methods.