### PR TITLE
Remove a bit of WisCon-specific verbiage from the Brainstorm-page

### DIFF
--- a/webpages/api/brainstorm/load_brainstorm.php
+++ b/webpages/api/brainstorm/load_brainstorm.php
@@ -1,12 +1,14 @@
 <?php
 
-if (!include ('../../../db_name.php')) {
-    include ('../../../db_name.php');
+if (!include ('../../config/db_name.php')) {
+    include ('../../config/db_name.php');
 }
 require_once('../../db_exceptions.php');
 require_once('../db_support_functions.php');
 require_once('../participant_functions.php');
 require_once('../jwt_functions.php');
+require_once('../con_info.php');
+
 
 function convert_database_date_to_date($db_date) {
     if ($db_date) {
@@ -19,57 +21,57 @@ function convert_database_date_to_date($db_date) {
 }
 
 function read_division_and_track_options($db) {
-    $query = <<<EOD
-    SELECT d.divisionid, d.divisionname, d.display_order, 
-           t.trackid, t.trackname, t.display_order as track_order,
-           k.from_time, k.to_time 
-     FROM Divisions d
-     LEFT OUTER JOIN con_key_dates k ON (d.external_key = k.external_key AND k.con_id = (select min(id) from current_con) )
-     JOIN Tracks t ON (d.divisionid = t.divisionid)
-    WHERE t.divisionid = d.divisionid
-      AND d.brainstorm_support = 'Y'
-    ORDER BY d.display_order, d.divisionid, track_order;
+	$query = <<<EOD
+	SELECT d.divisionid, d.divisionname, d.display_order, 
+		   t.trackid, t.trackname, t.display_order as track_order,
+		   k.from_time, k.to_time 
+	 FROM Divisions d
+	 LEFT OUTER JOIN con_key_dates k ON (d.external_key = k.external_key AND k.con_id = (select min(id) from current_con) )
+	 JOIN Tracks t ON (d.divisionid = t.divisionid)
+	WHERE t.divisionid = d.divisionid
+	  AND d.brainstorm_support = 'Y'
+	ORDER BY d.display_order, d.divisionid, track_order;
 EOD;
    
-    $stmt = mysqli_prepare($db, $query);
-    if (mysqli_stmt_execute($stmt)) {
-        $result = mysqli_stmt_get_result($stmt);
-        $options = array();
-        $current_division = null;
-        while ($row = mysqli_fetch_object($result)) {
+	$stmt = mysqli_prepare($db, $query);
+	if (mysqli_stmt_execute($stmt)) {
+		$result = mysqli_stmt_get_result($stmt);
+		$options = array();
+		$current_division = null;
+		while ($row = mysqli_fetch_object($result)) {
 
-            if ($current_division == null || $current_division['id'] !== $row->divisionid) {
-                if ($current_division != null) {
-                    $options[] = $current_division;
-                }
-                $from_time = convert_database_date_to_date($row->from_time);
-                $to_time = convert_database_date_to_date($row->to_time);
-                $current_division = array(
-                    "id" => $row->divisionid,
-                    "name" => $row->divisionname,
-                    "from_time" => $from_time ? date_format($from_time, "c") : null,
-                    "to_time" => $to_time ? date_format($to_time, "c") : null,
-                    "tracks" => array()
-                );
-            }
-            $track = array(
-                "trackid" => $row->trackid,
-                "trackname" => $row->trackname
-            );
-            array_push($current_division['tracks'], $track);
-        }
-        mysqli_stmt_close($stmt);
-        if ($current_division != null) {
-            $options[] = $current_division;
-        }
-        return $options;
-    } else {
-        throw new DatabaseSqlException($query);
-    }
+			if ($current_division == null || $current_division['id'] !== $row->divisionid) {
+				if ($current_division != null) {
+					$options[] = $current_division;
+				}
+				$from_time = convert_database_date_to_date($row->from_time);
+				$to_time = convert_database_date_to_date($row->to_time);
+				$current_division = array(
+					"id" => $row->divisionid,
+					"name" => $row->divisionname,
+					"from_time" => $from_time ? date_format($from_time, "c") : null,
+					"to_time" => $to_time ? date_format($to_time, "c") : null,
+					"tracks" => array()
+				);
+			}
+			$track = array(
+				"trackid" => $row->trackid,
+				"trackname" => $row->trackname
+			);
+			array_push($current_division['tracks'], $track);
+		}
+		mysqli_stmt_close($stmt);
+		if ($current_division != null) {
+			$options[] = $current_division;
+		}
+		return $options;
+	} else {
+		throw new DatabaseSqlException($query);
+	}
 }
 
 function create_jwt_for_badgeid($db, $badgeid) {
-    $query = <<<EOD
+	$query = <<<EOD
  SELECT 
         P.password, P.data_retention, P.badgeid, C.firstname, C.lastname, C.badgename, C.regtype 
    FROM 
@@ -77,45 +79,46 @@ function create_jwt_for_badgeid($db, $badgeid) {
    JOIN CongoDump C USING (badgeid)
   WHERE 
          P.badgeid = ?;
-EOD;
+ EOD;
 
-    $stmt = mysqli_prepare($db, $query);
-    mysqli_stmt_bind_param($stmt, "s", $badgeid);
-    if (mysqli_stmt_execute($stmt)) {
-        $result = mysqli_stmt_get_result($stmt);
-        if (mysqli_num_rows($result) == 1) {
-            $dbobject = mysqli_fetch_object($result);
-            mysqli_stmt_close($stmt);
-            return jwt_create_token($dbobject->badgeid, get_name($dbobject), $dbobject->regtype == null ? false : true);
-        } else {
-            return false;
-        }
-    } else {
-        throw new DatabaseSqlException($query);
-    }
+	$stmt = mysqli_prepare($db, $query);
+	mysqli_stmt_bind_param($stmt, "s", $badgeid);
+	if (mysqli_stmt_execute($stmt)) {
+		$result = mysqli_stmt_get_result($stmt);
+		if (mysqli_num_rows($result) == 1) {
+			$dbobject = mysqli_fetch_object($result);
+			mysqli_stmt_close($stmt);
+			return jwt_create_token($dbobject->badgeid, get_name($dbobject), $dbobject->regtype == null ? false : true);
+		} else {
+			return false;
+		}
+	} else {
+		throw new DatabaseSqlException($query);
+	}
 }
 
 $db = connect_to_db();
 session_start();
 try {
+	$currentCon = ConInfo::findCurrentCon($db);
 
-    $options = read_division_and_track_options($db);
-    $result = array("divisions" => $options);
+	$options = read_division_and_track_options($db);
+	$result = array("divisions" => $options, "con" => $currentCon->asJson());
 
-    // create JWT if already logged in
-    if (isset($_SESSION['badgeid'])) {
-        $jwt = create_jwt_for_badgeid($db, $_SESSION['badgeid']);
-        if ($jwt) {
-            header("Authorization: Bearer ".$jwt);
-        }
-    }
+	// create JWT if already logged in
+	if (isset($_SESSION['badgeid'])) {
+		$jwt = create_jwt_for_badgeid($db, $_SESSION['badgeid']);
+		if ($jwt) {
+			header("Authorization: Bearer ".$jwt);
+		}
+	}
 
-    header('Content-type: application/json');
-    $json_string = json_encode($result);
+	header('Content-type: application/json');
+	$json_string = json_encode($result);
     echo $json_string;
 
 } finally {
-    $db->close();
+	$db->close();
 }
 
 ?>

--- a/webpages/api/brainstorm/load_brainstorm.php
+++ b/webpages/api/brainstorm/load_brainstorm.php
@@ -1,8 +1,7 @@
 <?php
 
-if (!include ('../../config/db_name.php')) {
-    include ('../../config/db_name.php');
-}
+require_once ('../../config/db_name.php');
+
 require_once('../../db_exceptions.php');
 require_once('../db_support_functions.php');
 require_once('../participant_functions.php');
@@ -79,7 +78,7 @@ function create_jwt_for_badgeid($db, $badgeid) {
    JOIN CongoDump C USING (badgeid)
   WHERE 
          P.badgeid = ?;
- EOD;
+EOD;
 
 	$stmt = mysqli_prepare($db, $query);
 	mysqli_stmt_bind_param($stmt, "s", $badgeid);

--- a/webpages/api/brainstorm/load_brainstorm.php
+++ b/webpages/api/brainstorm/load_brainstorm.php
@@ -20,57 +20,57 @@ function convert_database_date_to_date($db_date) {
 }
 
 function read_division_and_track_options($db) {
-	$query = <<<EOD
-	SELECT d.divisionid, d.divisionname, d.display_order, 
-		   t.trackid, t.trackname, t.display_order as track_order,
-		   k.from_time, k.to_time 
-	 FROM Divisions d
-	 LEFT OUTER JOIN con_key_dates k ON (d.external_key = k.external_key AND k.con_id = (select min(id) from current_con) )
-	 JOIN Tracks t ON (d.divisionid = t.divisionid)
-	WHERE t.divisionid = d.divisionid
-	  AND d.brainstorm_support = 'Y'
-	ORDER BY d.display_order, d.divisionid, track_order;
+    $query = <<<EOD
+    SELECT d.divisionid, d.divisionname, d.display_order, 
+           t.trackid, t.trackname, t.display_order as track_order,
+           k.from_time, k.to_time 
+     FROM Divisions d
+     LEFT OUTER JOIN con_key_dates k ON (d.external_key = k.external_key AND k.con_id = (select min(id) from current_con) )
+     JOIN Tracks t ON (d.divisionid = t.divisionid)
+    WHERE t.divisionid = d.divisionid
+      AND d.brainstorm_support = 'Y'
+    ORDER BY d.display_order, d.divisionid, track_order;
 EOD;
    
-	$stmt = mysqli_prepare($db, $query);
-	if (mysqli_stmt_execute($stmt)) {
-		$result = mysqli_stmt_get_result($stmt);
-		$options = array();
-		$current_division = null;
-		while ($row = mysqli_fetch_object($result)) {
+    $stmt = mysqli_prepare($db, $query);
+    if (mysqli_stmt_execute($stmt)) {
+        $result = mysqli_stmt_get_result($stmt);
+        $options = array();
+        $current_division = null;
+        while ($row = mysqli_fetch_object($result)) {
 
-			if ($current_division == null || $current_division['id'] !== $row->divisionid) {
-				if ($current_division != null) {
-					$options[] = $current_division;
-				}
-				$from_time = convert_database_date_to_date($row->from_time);
-				$to_time = convert_database_date_to_date($row->to_time);
-				$current_division = array(
-					"id" => $row->divisionid,
-					"name" => $row->divisionname,
-					"from_time" => $from_time ? date_format($from_time, "c") : null,
-					"to_time" => $to_time ? date_format($to_time, "c") : null,
-					"tracks" => array()
-				);
-			}
-			$track = array(
-				"trackid" => $row->trackid,
-				"trackname" => $row->trackname
-			);
-			array_push($current_division['tracks'], $track);
-		}
-		mysqli_stmt_close($stmt);
-		if ($current_division != null) {
-			$options[] = $current_division;
-		}
-		return $options;
-	} else {
-		throw new DatabaseSqlException($query);
-	}
+            if ($current_division == null || $current_division['id'] !== $row->divisionid) {
+                if ($current_division != null) {
+                    $options[] = $current_division;
+                }
+                $from_time = convert_database_date_to_date($row->from_time);
+                $to_time = convert_database_date_to_date($row->to_time);
+                $current_division = array(
+                    "id" => $row->divisionid,
+                    "name" => $row->divisionname,
+                    "from_time" => $from_time ? date_format($from_time, "c") : null,
+                    "to_time" => $to_time ? date_format($to_time, "c") : null,
+                    "tracks" => array()
+                );
+            }
+            $track = array(
+                "trackid" => $row->trackid,
+                "trackname" => $row->trackname
+            );
+            array_push($current_division['tracks'], $track);
+        }
+        mysqli_stmt_close($stmt);
+        if ($current_division != null) {
+            $options[] = $current_division;
+        }
+        return $options;
+    } else {
+        throw new DatabaseSqlException($query);
+    }
 }
 
 function create_jwt_for_badgeid($db, $badgeid) {
-	$query = <<<EOD
+    $query = <<<EOD
  SELECT 
         P.password, P.data_retention, P.badgeid, C.firstname, C.lastname, C.badgename, C.regtype 
    FROM 
@@ -80,44 +80,44 @@ function create_jwt_for_badgeid($db, $badgeid) {
          P.badgeid = ?;
 EOD;
 
-	$stmt = mysqli_prepare($db, $query);
-	mysqli_stmt_bind_param($stmt, "s", $badgeid);
-	if (mysqli_stmt_execute($stmt)) {
-		$result = mysqli_stmt_get_result($stmt);
-		if (mysqli_num_rows($result) == 1) {
-			$dbobject = mysqli_fetch_object($result);
-			mysqli_stmt_close($stmt);
-			return jwt_create_token($dbobject->badgeid, get_name($dbobject), $dbobject->regtype == null ? false : true);
-		} else {
-			return false;
-		}
-	} else {
-		throw new DatabaseSqlException($query);
-	}
+    $stmt = mysqli_prepare($db, $query);
+    mysqli_stmt_bind_param($stmt, "s", $badgeid);
+    if (mysqli_stmt_execute($stmt)) {
+        $result = mysqli_stmt_get_result($stmt);
+        if (mysqli_num_rows($result) == 1) {
+            $dbobject = mysqli_fetch_object($result);
+            mysqli_stmt_close($stmt);
+            return jwt_create_token($dbobject->badgeid, get_name($dbobject), $dbobject->regtype == null ? false : true);
+        } else {
+            return false;
+        }
+    } else {
+        throw new DatabaseSqlException($query);
+    }
 }
 
 $db = connect_to_db();
 session_start();
 try {
-	$currentCon = ConInfo::findCurrentCon($db);
+    $currentCon = ConInfo::findCurrentCon($db);
 
-	$options = read_division_and_track_options($db);
-	$result = array("divisions" => $options, "con" => $currentCon->asJson());
+    $options = read_division_and_track_options($db);
+    $result = array("divisions" => $options, "con" => $currentCon->asJson());
 
-	// create JWT if already logged in
-	if (isset($_SESSION['badgeid'])) {
-		$jwt = create_jwt_for_badgeid($db, $_SESSION['badgeid']);
-		if ($jwt) {
-			header("Authorization: Bearer ".$jwt);
-		}
-	}
+    // create JWT if already logged in
+    if (isset($_SESSION['badgeid'])) {
+        $jwt = create_jwt_for_badgeid($db, $_SESSION['badgeid']);
+        if ($jwt) {
+            header("Authorization: Bearer ".$jwt);
+        }
+    }
 
-	header('Content-type: application/json');
-	$json_string = json_encode($result);
+    header('Content-type: application/json');
+    $json_string = json_encode($result);
     echo $json_string;
 
 } finally {
-	$db->close();
+    $db->close();
 }
 
 ?>

--- a/webpages/api/brainstorm/submit_session.php
+++ b/webpages/api/brainstorm/submit_session.php
@@ -1,8 +1,7 @@
 <?php
 
-if (!include ('../../config/db_name.php')) {
-    include ('../../config/db_name.php');
-}
+require_once ('../../config/db_name.php');
+
 require_once('../../external/swiftmailer-5.4.8/lib/swift_required.php');
 require_once('../../db_exceptions.php');
 require_once('../db_support_functions.php');
@@ -14,7 +13,7 @@ function find_select_dropdown_by_name($db, $table, $idcolumn, $keycolumnname, $k
 
     $query = <<<EOD
  SELECT $idcolumn as id FROM $table WHERE $keycolumnname = ?;
- EOD;
+EOD;
 
     $stmt = mysqli_prepare($db, $query);
     mysqli_stmt_bind_param($stmt, "s", $key);
@@ -36,7 +35,7 @@ function find_division($db, $divisionId) {
 
     $query = <<<EOD
  SELECT email_address, divisionname FROM Divisions WHERE divisionid = ?;
- EOD;
+EOD;
 
     $stmt = mysqli_prepare($db, $query);
     mysqli_stmt_bind_param($stmt, "i", $divisionId);
@@ -67,7 +66,7 @@ function write_session_to_database($db, $json, $jwt) {
             (title, progguiddesc, servicenotes, persppartinfo,
             divisionid, statusid, kidscatid, trackid, typeid, pubstatusid, roomsetid, duration, pocketprogtext, notesforprog)
     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
-   EOD;
+EOD;
 
         $stmt = mysqli_prepare($db, $query);
         mysqli_stmt_bind_param($stmt, "ssssiiiiiiisss", $json['title'], $json['progguiddesc'], 
@@ -90,7 +89,7 @@ function write_session_to_database($db, $json, $jwt) {
             (sessionid, badgeid, name, email_address,
             sessioneditcode, statusid, editdescription)
     VALUES (?, ?, ?, ?, ?, ?, ?);
-   EOD;
+EOD;
 
         $stmt = mysqli_prepare($db, $query);
         mysqli_stmt_bind_param($stmt, "isssiis", $sessionId, $badgeid, 
@@ -129,7 +128,7 @@ function get_email_address_for_badgeid($db, $badgeid) {
         JOIN CongoDump C USING (badgeid)
         WHERE 
             P.badgeid = ?;
-    EOD;
+EOD;
     $stmt = mysqli_prepare($db, $query);
     mysqli_stmt_bind_param($stmt, "s", $badgeid);
     if (mysqli_stmt_execute($stmt)) {
@@ -159,7 +158,7 @@ function get_name_for_badgeid($db, $badgeid) {
         JOIN CongoDump C USING (badgeid)
         WHERE 
             P.badgeid = ?;
-    EOD;
+EOD;
     $stmt = mysqli_prepare($db, $query);
     mysqli_stmt_bind_param($stmt, "s", $badgeid);
     if (mysqli_stmt_execute($stmt)) {

--- a/webpages/api/brainstorm/submit_session.php
+++ b/webpages/api/brainstorm/submit_session.php
@@ -1,7 +1,7 @@
 <?php
 
-if (!include ('../../../db_name.php')) {
-	include ('../../../db_name.php');
+if (!include ('../../config/db_name.php')) {
+    include ('../../config/db_name.php');
 }
 require_once('../../external/swiftmailer-5.4.8/lib/swift_required.php');
 require_once('../../db_exceptions.php');

--- a/webpages/api/con_info.php
+++ b/webpages/api/con_info.php
@@ -1,0 +1,55 @@
+<?php
+
+class ConInfo {
+
+    public $id;
+    public $name;
+    public $startDate;
+    public $endDate;
+
+    function __construct($id, $name, $startDate, $endDate) {
+        $this->id = $id;
+        $this->name = $name;
+        $this->startDate = $startDate;
+        $this->endDate = $endDate;
+    }
+
+    function asJson() {
+        return array("id" => $this->id, "name" => $this->name,
+            "startDate" => $this->startDate, "endDate" => $this->endDate);
+    }
+
+    public static function asJsonList($cons) {
+        $result = array();
+        foreach ($cons as $con) {
+            $result[] = $con->asJson();
+        }
+        return array("list" => $result);        
+    }
+
+    public static function findCurrentCon($db) {
+        $query = <<<EOD
+        SELECT 
+               id, name, con_start_date, con_end_date
+          FROM 
+               current_con;
+EOD;
+       
+        $stmt = mysqli_prepare($db, $query);
+        if (mysqli_stmt_execute($stmt)) {
+            $resultSet = mysqli_stmt_get_result($stmt);
+            if (mysqli_num_rows($resultSet) == 1) {
+                $dbobject = mysqli_fetch_object($resultSet);
+                mysqli_stmt_close($stmt);
+                $result = new ConInfo($dbobject->id, $dbobject->name, $dbobject->con_start_date, $dbobject->con_end_date);
+                return $result;
+            } else {
+                throw new DatabaseException("Expected one result, but found " . mysqli_num_rows($resultSet));
+            }
+        } else {
+            return new DatabaseSqlException("Query could not be executed: $query");
+        }
+    }
+}
+
+?>

--- a/webpages/brainstorm/src/component/submissionForm.js
+++ b/webpages/brainstorm/src/component/submissionForm.js
@@ -16,6 +16,7 @@ dayjs.extend(timezone);
 dayjs.extend(advancedFormat);
 
 import store from '../state/store';
+import { connect } from 'react-redux';
 
 class SubmissionForm extends Component {
 
@@ -197,6 +198,7 @@ class SubmissionForm extends Component {
         let fieldNames = this.getFieldList(this.getSelectedDivision());
         let fields = fieldNames.map((n) => { return this.createField(n); });
 
+        let proem = this.props.con ? (<p>Submissions are open for programming for {this.props.con.name}.</p>) : undefined;
         return (
             <Form onSubmit={(e) =>  this.submitForm(e)}>
                 {message}
@@ -204,7 +206,7 @@ class SubmissionForm extends Component {
                 <Card>
                     <Card.Header><h2>Submit a Session</h2></Card.Header>
                     <Card.Body>
-                        <p>Submissions are open for programming for WisCon 2022.</p>
+                        {proem}
 
                         {fields}
 
@@ -385,4 +387,8 @@ class SubmissionForm extends Component {
     }
 }
 
-export default SubmissionForm;
+function mapStateToProps(state) {
+    return { con: state.options.con };
+}
+
+export default connect(mapStateToProps)(SubmissionForm);

--- a/webpages/brainstorm/src/state/store.js
+++ b/webpages/brainstorm/src/state/store.js
@@ -48,6 +48,7 @@ const options = (state = {}, action) => {
     switch (action.type) {
         case SAVE_OPTIONS: 
             return { ...state,
+                con: action.payload.con,
                 divisions: action.payload.divisions 
             };
         default:


### PR DESCRIPTION
While doing some debugging with James, I remembered that I hadn't pushed this change from the WisCon codebase over to PlanZ. 

This PR generalizes a "Now taking submissions for WisCon 2022" message so that it uses the con information from the database. 

There are other WisCon-specific things in brainstorm, which I'll chat with James about fixing.