### PR TITLE
Use PHP redirect to get theme favicon for Brainstorming

### DIFF
--- a/webpages/FavIcon.php
+++ b/webpages/FavIcon.php
@@ -1,0 +1,13 @@
+<?php
+//	Created by James Shields
+//  This file providees a consistent URL for requesting the PlanZ configurable "favicon" image
+
+require_once('./config/db_name.php');
+
+if (defined('CON_HEADER_IMG') && CON_THEME_FAVICON !== "") {
+    header('Location: ' . CON_THEME_FAVICON);
+} else {
+    header('Location: images/favicon.ico');
+}
+
+?>

--- a/webpages/brainstorm/public/index.html
+++ b/webpages/brainstorm/public/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <link rel="shortcut icon" href="/themes/wiscon/favicon.png">
+        <link rel="shortcut icon" href="/FavIcon.php">
         <title>WisCon Panel Idea Submission/Brainstorm</title>
     </head>
     <body>


### PR DESCRIPTION
First step of fixing theming in Brainstorming.
- Add FavIcon.php to redirect to correct FavIcon image from Theme.
- Change Brainstorming index.html to reference FavIcon.