### PR TITLE
Improvements to the Volunteer Pages

### DIFF
--- a/client/src/page/volunteer/volunteerSighUpOption.jsx
+++ b/client/src/page/volunteer/volunteerSighUpOption.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import Button from 'react-bootstrap/Button';
+
+import LoadingButton from "../../common/loadingButton";
+import { renderDateRange } from '../../util/dateUtil';
+
+class VolunteerSignUpOption extends React.Component {
+
+    constructor(props) {
+        super(props);
+        this.state = {
+            loading: false,
+            showDetails: false
+        }
+    }
+
+    render() {
+        let shift = this.props.shift;
+        let emphasis = this.highNeed(shift);
+        return (<div className={'card mb-3 ' + (emphasis ? 'border-primary' : '')} >
+            <div className="card-body">
+                <div className="row">
+                    <div className="col-md-12"><b>{shift.job.name}:</b> {renderDateRange(shift.fromTime, shift.toTime, this.props.timezone)}</div>                        
+                </div>
+                <div className="row">
+                    <div className="col-md-6"><b>Needs:</b> {shift.minPeople}&ndash;{shift.maxPeople} volunteers <span>(has {shift.currentSignupCount})</span></div>
+                    <div className="col-md-6"><b>Location:</b> {shift.location} </div>
+                </div>
+                {this.state.showDetails ? (<div className="row">
+                    <div className="col-md-12 small">{shift.job.description}</div>
+                </div>) : undefined}
+                <div className="row align-items-end">
+                    <div className="col-md-6">
+                        <Button variant="outline-secondary" className="btn-sm mr-2" onClick={() => this.setState((state) => ({...state, showDetails: !state.showDetails }))}>
+                            {this.state.showDetails ? 'hide details' : 'details'}
+                        </Button>
+                    </div>
+                    <div className="col-md-6 text-right">
+                        <LoadingButton onClick={() => {
+                            this.setState((state) => ({...state, loading: true }));
+                            this.props.onClick(shift);
+                        }} enabled={true} loading={this.state.loading}>Add</LoadingButton>
+                    </div>
+                </div>
+            </div>
+        </div>);
+    }
+
+    highNeed(shift) {
+        return shift.currentSignupCount < shift.minPeople;
+    }
+}
+
+export default VolunteerSignUpOption;

--- a/client/src/page/volunteer/volunteerSignUpAddModal.jsx
+++ b/client/src/page/volunteer/volunteerSignUpAddModal.jsx
@@ -13,6 +13,7 @@ import timezone from 'dayjs/plugin/timezone';
 import advancedFormat from "dayjs/plugin/advancedFormat"
 import customParseFormat from "dayjs/plugin/customParseFormat"
 import { formatDay } from '../../util/dateUtil';
+import VolunteerSignUpOption from './volunteerSighUpOption';
 dayjs.extend(utc);
 dayjs.extend(timezone);
 dayjs.extend(customParseFormat);
@@ -98,20 +99,7 @@ class VolunteerSignUpAddModal extends React.Component {
 
     renderListOfShifts(shifts) {
         return shifts.filter(s => !this.isExistingAssignment(s) && this.matchesFilter(s)).map((s, i) => {
-            let emphasis = this.highNeed(s);
-            return (<div className={'card mb-3 ' + (emphasis ? 'border-primary' : '')} key={'shift-' + s.id}>
-                <div className="card-body">
-                    <div className="row">
-                        <div className="col-md-6"><b>{s.job.name}:</b> {renderDateRange(s.fromTime, s.toTime, this.props.shifts.context.timezone)}</div>                        
-                        <div className="col-md-6"><b>Location:</b> {s.location} </div>
-                    </div>
-                    <div className="row">
-                        <div className="col-md-6"><b>Needs:</b> {s.minPeople}&ndash;{s.maxPeople} volunteers <span>(has {s.currentSignupCount})</span></div>
-                        <div className="col-md-6 text-right"><LoadingButton onClick={() => this.addShiftToMyAssignments(s)} enabled={true} 
-                            loading={this.state.loadingId == s.id}>Add</LoadingButton></div>
-                    </div>
-                </div>
-            </div>)
+            return (<VolunteerSignUpOption shift={s} timezone={this.props.shifts.context.timezone} onClick={(shift) => this.addShiftToMyAssignments(shift) } key={'shift-' + s.id}/>);
         });
     }
 
@@ -186,10 +174,6 @@ class VolunteerSignUpAddModal extends React.Component {
         let result = false;
         this.props.assignments.list.forEach(a => result |= (a.id == shift.id));
         return result;
-    }
-
-    highNeed(shift) {
-        return shift.currentSignupCount < shift.minPeople;
     }
 }
 

--- a/client/src/state/store.js
+++ b/client/src/state/store.js
@@ -1,5 +1,5 @@
 import { createStore, combineReducers } from 'redux'
-import { SET_SHIFT_ASSIGNMENTS, SET_VOLUNTEER_JOBS, SET_VOLUNTEER_SHIFTS, SHOW_CREATE_JOB_MODAL, SHOW_CREATE_SHIFT_MODAL } from './volunteerActions';
+import { REMEMBER_RECENT_SHIFT_DATA, SET_SHIFT_ASSIGNMENTS, SET_VOLUNTEER_JOBS, SET_VOLUNTEER_SHIFTS, SHOW_CREATE_JOB_MODAL, SHOW_CREATE_SHIFT_MODAL } from './volunteerActions';
 import moduleReducer from './moduleReducer';
 
 const volunteerInitialState = {
@@ -20,6 +20,8 @@ const volunteerInitialState = {
         selectedJob: null,
         loading: true,
         list: []
+    },
+    recentData: {
     }
 }
 
@@ -74,6 +76,11 @@ const volunteering = (state = volunteerInitialState, action) => {
                     showModal: action.payload.show,
                     selectedShift: action.payload.selectedShift
                 }
+            }
+        case REMEMBER_RECENT_SHIFT_DATA: 
+            return {
+                ...state,
+                recentData: action.payload.values
             }
         default:
             return state;

--- a/client/src/state/volunteerActions.js
+++ b/client/src/state/volunteerActions.js
@@ -3,6 +3,7 @@ export const SHOW_CREATE_JOB_MODAL = 'SHOW_CREATE_JOB_MODAL';
 export const SET_VOLUNTEER_SHIFTS = 'SET_VOLUNTEER_SHIFTS';
 export const SHOW_CREATE_SHIFT_MODAL = 'SHOW_CREATE_SHIFT_MODAL';
 export const SET_SHIFT_ASSIGNMENTS = 'SET_SHIFT_ASSIGNMENTS';
+export const REMEMBER_RECENT_SHIFT_DATA = 'REMEMBER_RECENT_SHIFT_DATA';
 
 export function setVolunteerJobs(jobs, message = null) {
     let payload = {
@@ -55,6 +56,16 @@ export function showCreateShiftModal(show = true, shift = null) {
     }
     return {
         type: SHOW_CREATE_SHIFT_MODAL,
+        payload
+    }
+}
+
+export function rememberRecentShiftData(values) {
+    let payload = {
+        values: values
+    }
+    return {
+        type: REMEMBER_RECENT_SHIFT_DATA,
         payload
     }
 }


### PR DESCRIPTION
Based on some feedback from WisCon, I've made a few tweaks to the volunteer functionality. There are two changes:

1. When users are signing up for volunteer shifts, we now give them a "details" button so that they can see the job descriptions, which gives them more information about the nature of the volunteer assignment. The descriptions can be long, so I didn't want to show them in all cases.
2. When coordinators are creating volunteer shifts, they're often providing much the same information over and over again. ("I need 1-4 Runners for Saturday from 8am to 10am", "I need 1-4 Runners for Saturday from 10am to 12noon" etc.) So I now remember the data from the last shift they created (in the current "session"), and re-present that data so that the user can just change the stuff that's different.