### PR TITLE
Add "Type" as a tag in KonOpas/ConClár export

### DIFF
--- a/webpages/konOpas_func.php
+++ b/webpages/konOpas_func.php
@@ -81,10 +81,9 @@ EOD;
     $results["program_num_rows"] = mysqli_num_rows($result);        //used for reporting
     $program = array();
     while($row = mysqli_fetch_assoc($result)) {
-        $tagsArray = array("Track:".$row["trackname"],"Division:".$row["divisionname"]);
-        $temparrayoftags = array();
+        $tagsArray = array("Track:".$row["trackname"], "Division:".$row["divisionname"]);
         if (!empty($row['typename'])) {
-            $temparrayoftags[] = 'Type:'.$row['typename'];
+            $tagsArray[] = 'Type:'.$row['typename'];
         }
         if (!empty($row["taglist"])) {
             $temparrayoftags = explode(',', $row["taglist"]);

--- a/webpages/konOpas_func.php
+++ b/webpages/konOpas_func.php
@@ -82,11 +82,14 @@ EOD;
     $program = array();
     while($row = mysqli_fetch_assoc($result)) {
         $tagsArray = array("Track:".$row["trackname"],"Division:".$row["divisionname"]);
+        $temparrayoftags = array();
+        if (!empty($row['typename'])) {
+            $temparrayoftags[] = 'Type:'.$row['typename'];
+        }
         if (!empty($row["taglist"])) {
-            $temparrayoftags = array();
             $temparrayoftags = explode(',', $row["taglist"]);
             foreach ($temparrayoftags as $singletag) {
-                array_push($tagsArray,"Tag:".$singletag);
+                array_push($tagsArray, "Tag:".$singletag);
             }
         }
         $locfloor = '';


### PR DESCRIPTION
Currently the Session Type is not included in the KonOpas/ConClár export. This change adds the type to each session's tags with the "Type:" prefix.