### PR TITLE
Ignore participant photos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,15 @@ webpages/vendor/
 webpages/config/db_name.php
 webpages/config/db_env.php
 webpages/config/db.php
+webpages/config/db_name_backup_*.php
+
+# Exclude participant photos.
+webpages/participant_photos/*.jpg
+webpages/participant_photos/*.png
+webpages/participant_photos/*.gif
+webpages/participant_photos/*.webp
+
+# Folders that won't necessarily in the project space, but since the root is outside webroot, they could be.
+private/
+upload_photos/
+

--- a/webpages/config/db_name_sample.php
+++ b/webpages/config/db_name_sample.php
@@ -98,7 +98,6 @@ define("PHOTO_DEFAULT_IMAGE", "default.png"); // placeholder image for participa
 
 define("JSON_EXTRACT_DIRECTORY", "/var/data/guide/");  // Path to directory where Konopas/ConClár files to be written.
 define("JSON_EXTRACT_ASSIGN_VARS", FALSE); // If TRUE include variable names in JSON output files (required for KonOpas).
-define("JSON_EXTRACT_DIRECTORY", "/var/data/guide/");  // Path to directory where Konopas/ConClár files to be written.
 
 define("PHOTO_EXTRACT_LINK_TYPE", ""); // Link type to use when exporting photos to KonOpas/ConClár.
         // Supported values: "img", "photo" or "img_256_url" (the last one comes from Grenadine, so not really recommended).

--- a/webpages/config/db_name_sample.php
+++ b/webpages/config/db_name_sample.php
@@ -98,6 +98,7 @@ define("PHOTO_DEFAULT_IMAGE", "default.png"); // placeholder image for participa
 
 define("JSON_EXTRACT_DIRECTORY", "/var/data/guide/");  // Path to directory where Konopas/ConClár files to be written.
 define("JSON_EXTRACT_ASSIGN_VARS", FALSE); // If TRUE include variable names in JSON output files (required for KonOpas).
+define("JSON_EXTRACT_DIRECTORY", "/var/data/guide/");  // Path to directory where Konopas/ConClár files to be written.
 
 define("PHOTO_EXTRACT_LINK_TYPE", ""); // Link type to use when exporting photos to KonOpas/ConClár.
         // Supported values: "img", "photo" or "img_256_url" (the last one comes from Grenadine, so not really recommended).


### PR DESCRIPTION
Add files to .gitignore.
This includes participant photos in all the image formats I could think of (without excluding the default image svg).
Also excludes "private" and "upload_photos" directoories outside the root.
Added pattern for db_name backup files in anticipation of future change.