### PR TITLE
Edit config column widths

### DIFF
--- a/webpages/SubmitEditConfigTable.php
+++ b/webpages/SubmitEditConfigTable.php
@@ -11,6 +11,10 @@ $displayorder_found = false;
 $prikey = '';
 $json_return = array();
 
+/**
+ * Return maximum length of column contents.
+ * Used in calculating more accurate table editor column widths.
+ */
 function fetch_max_length(string $tablename, $columnName): int
 {
     $query = "SELECT MAX(LENGTH($columnName)) FROM $tablename;";
@@ -42,6 +46,7 @@ EOD;
         $displayorder_found = false;
         $prikey = '';
         while ($row = $result->fetch_assoc()) {
+            // Add actual width of contents to results.
             $row['ACTUAL_LENGTH'] = fetch_max_length($tablename, $row['COLUMN_NAME']);
             $schema[] = $row;
             if ($row["COLUMN_NAME"] == 'display_order') {

--- a/webpages/SubmitEditConfigTable.php
+++ b/webpages/SubmitEditConfigTable.php
@@ -11,6 +11,14 @@ $displayorder_found = false;
 $prikey = '';
 $json_return = array();
 
+function fetch_max_length(string $tablename, $columnName): int
+{
+    $query = "SELECT MAX(LENGTH($columnName)) FROM $tablename;";
+    $result = mysqli_query_exit_on_error($query);
+    $row = $result->fetch_row();
+    return $row[0] ?? 0;
+}
+
 function fetch_schema($tablename) {
     global $schema, $displayorder_found, $prikey, $schema_loaded;
 
@@ -34,6 +42,7 @@ EOD;
         $displayorder_found = false;
         $prikey = '';
         while ($row = $result->fetch_assoc()) {
+            $row['ACTUAL_LENGTH'] = fetch_max_length($tablename, $row['COLUMN_NAME']);
             $schema[] = $row;
             if ($row["COLUMN_NAME"] == 'display_order') {
                 $displayorder_found = true;

--- a/webpages/js/EditConfigTables.js
+++ b/webpages/js/EditConfigTables.js
@@ -206,6 +206,21 @@ function cellChanged(cell) {
     cell.getElement().style.backgroundColor = "#fff3cd";
 }
 
+/**
+ * Function to return the width of a column in characters.
+ * @param {object} column The column propertes.
+ * @return {int}
+ */
+function calculateColumnWidth(column) {
+    // If no data in column, set width to maxmum length.
+    if (!colLength) return column.CHARACTER_MAXIMUM_LENGTH;
+    // If column contains data, set column width to maximum existing length + 25%.
+    const colLength = column.ACTUAL_LENGTH + column.ACTUAL_LENGTH % 4;
+    // If that would make it longer than maxium length, set to maximum length.
+    if (colLength > column.CHARACTER_MAXIMUM_LENGTH) return column.CHARACTER_MAXIMUM_LENGTH;
+    return colLength;
+}
+
 function opentable(tabledata) {
     // get table information from tableschema
     //console.log(tableschema);
@@ -249,12 +264,7 @@ function opentable(tabledata) {
                 cellClick: tceEditorBlur
             });
         else if (column.DATA_TYPE == 'text') {
-            // If no data in column, set width to maxmum length.
-            // If column contains data, set column width to maximum existing length + 25%.
-            // If that would make it longer than maxium length, set to maximum length.
-            let colLength = column.ACTUAL_LENGTH + column.ACTUAL_LENGTH % 4;
-            if (!colLength || colLength > column.CHARACTER_MAXIMUM_LENGTH) colLength = column.CHARACTER_MAXIMUM_LENGTH;
-            width = 8 * colLength;
+            width = 8 * calculateColumnWidth(column);
             if (width < 80) width = 80;
             if (width > 500) width = 500;
             columns.push({
@@ -262,10 +272,7 @@ function opentable(tabledata) {
                 cellClick: tceEditor
             });
         } else {
-            // Same length rules as text type.
-            let colLength = column.ACTUAL_LENGTH + column.ACTUAL_LENGTH % 4;
-            if (!colLength || colLength > column.CHARACTER_MAXIMUM_LENGTH) colLength = column.CHARACTER_MAXIMUM_LENGTH;
-            width = 8 * colLength;
+            width = 8 * calculateColumnWidth(column);
             if (width < 80) width = 80;
             if (width > 500) width = 500;
             columns.push({

--- a/webpages/js/EditConfigTables.js
+++ b/webpages/js/EditConfigTables.js
@@ -249,7 +249,12 @@ function opentable(tabledata) {
                 cellClick: tceEditorBlur
             });
         else if (column.DATA_TYPE == 'text') {
-            width = 8 * column.CHARACTER_MAXIMUM_LENGTH;
+            // If no data in column, set width to maxmum length.
+            // If column contains data, set column width to maximum existing length + 25%.
+            // If that would make it longer than maxium length, set to maximum length.
+            let colLength = column.ACTUAL_LENGTH + column.ACTUAL_LENGTH % 4;
+            if (!colLength || colLength > column.CHARACTER_MAXIMUM_LENGTH) colLength = column.CHARACTER_MAXIMUM_LENGTH;
+            width = 8 * colLength;
             if (width < 80) width = 80;
             if (width > 500) width = 500;
             columns.push({
@@ -257,7 +262,10 @@ function opentable(tabledata) {
                 cellClick: tceEditor
             });
         } else {
-            width = 8 * column.CHARACTER_MAXIMUM_LENGTH;
+            // Same length rules as text type.
+            let colLength = column.ACTUAL_LENGTH + column.ACTUAL_LENGTH % 4;
+            if (!colLength || colLength > column.CHARACTER_MAXIMUM_LENGTH) colLength = column.CHARACTER_MAXIMUM_LENGTH;
+            width = 8 * colLength;
             if (width < 80) width = 80;
             if (width > 500) width = 500;
             columns.push({

--- a/webpages/js/EditConfigTables.js
+++ b/webpages/js/EditConfigTables.js
@@ -213,7 +213,7 @@ function cellChanged(cell) {
  */
 function calculateColumnWidth(column) {
     // If no data in column, set width to maxmum length.
-    if (!colLength) return column.CHARACTER_MAXIMUM_LENGTH;
+    if (!column.ACTUAL_LENGTH) return column.CHARACTER_MAXIMUM_LENGTH;
     // If column contains data, set column width to maximum existing length + 25%.
     const colLength = column.ACTUAL_LENGTH + column.ACTUAL_LENGTH % 4;
     // If that would make it longer than maxium length, set to maximum length.


### PR DESCRIPTION
This change is to improve the readability of tables with wide columns in the table configuration editor. In particular the Rooms table.
If columns contain data, the column width will be set based on the existing data in the table.