### PR TITLE
Add tables needed for Brainstorming to configuration table editor

### DIFF
--- a/Install/Upgrade_dbase/88ZED_brainstorm_ce_permissions.sql
+++ b/Install/Upgrade_dbase/88ZED_brainstorm_ce_permissions.sql
@@ -1,0 +1,23 @@
+## This script adds permission atoms for table editing of brainstorm tables and does default assignment to admin of those atoms
+##
+##    Created by James Shields on 2022-10-19
+##     Copyright (c) 2021 by Peter Olszowka. All rights reserved. See copyright document for more details.
+##
+
+INSERT INTO PermissionAtoms(permatomid, permatomtag, page, notes)
+VALUES
+    (2062, 'ce_perennial_con_info', 'Edit Configuration Tables', 'enables edit'),
+    (2063, 'ce_con_info', 'Edit Configuration Tables', 'enables edit'),
+    (2064, 'ce_con_key_dates', 'Edit Configuration Tables', 'enables edit');
+
+INSERT INTO Permissions(permatomid, phaseid, permroleid)
+SELECT a.permatomid, null, r.permroleid 
+FROM PermissionAtoms a
+JOIN PermissionRoles r ON (r.permrolename = 'Administrator')
+WHERE permatomtag IN ('ce_perennial_con_info', 'ce_con_info', 'ce_con_key_dates');
+
+ALTER TABLE perennial_con_info ADD display_order INT NULL AFTER name;
+ALTER TABLE con_info ADD display_order INT NULL AFTER name;
+ALTER TABLE con_key_dates ADD display_order INT NULL AFTER con_id;
+
+INSERT INTO PatchLog (patchname) VALUES ('88ZED_brainstorm_ce_permissions.sql');

--- a/webpages/xsl/ConfigTableEditor.xsl
+++ b/webpages/xsl/ConfigTableEditor.xsl
@@ -97,9 +97,15 @@
             select="/doc/query[@queryname='permission_set']/row[@permatomtag='ce_Locations' or @permatomtag='ce_All']" />
         <xsl:variable name="editRegTypes"
             select="/doc/query[@queryname='permission_set']/row[@permatomtag='ce_RegTypes' or @permatomtag='ce_All']" />
+        <xsl:variable name="editPerennialConInfo"
+            select="/doc/query[@queryname='permission_set']/row[@permatomtag='ce_perennial_con_info' or @permatomtag='ce_All']" />
+        <xsl:variable name="editConInfo"
+            select="/doc/query[@queryname='permission_set']/row[@permatomtag='ce_con_info' or @permatomtag='ce_All']" />
+        <xsl:variable name="editConKeyDates"
+            select="/doc/query[@queryname='permission_set']/row[@permatomtag='ce_con_key_dates' or @permatomtag='ce_All']" />
 
         <xsl:variable name="editAnyMisc"
-            select="$editDivisions or $editLocations or $editRegTypes" />
+            select="$editDivisions or $editLocations or $editRegTypes or editPerennialConInfo or editConInfo or editConKeyDates" />
 
 
         <xsl:variable name="editAnyThing"
@@ -708,6 +714,27 @@
                                         </a>
                                     </li>
                                 </xsl:if>
+                                <xsl:if test="$editPerennialConInfo">
+                                    <li class="nav-item">
+                                        <a href="#perennial_con_info" class="nav-link" data-toggle="tab" data-top="misc-top"
+                                           id="t-perennial_con_info">Perennial Con Info
+                                        </a>
+                                    </li>
+                                </xsl:if>
+                                <xsl:if test="$editConInfo">
+                                    <li class="nav-item">
+                                        <a href="#con_info" class="nav-link" data-toggle="tab" data-top="misc-top"
+                                           id="t-con_info">Con Info
+                                        </a>
+                                    </li>
+                                </xsl:if>
+                                <xsl:if test="$editConKeyDates">
+                                    <li class="nav-item">
+                                        <a href="#con_key_dates" class="nav-link" data-toggle="tab" data-top="misc-top"
+                                           id="t-con_key_dates">Con Key Dates
+                                        </a>
+                                    </li>
+                                </xsl:if>
                             </ul>
                             <div class="tab-content">
                                 <div class="tab-pane mt-4 fade show active" id="miscdesc">
@@ -721,6 +748,18 @@
                                             <li>RegTypes</li>
                                             <p>The type of member registration the participant has</p>
                                         </xsl:if>
+                                        <xsl:if test="$editPerennialConInfo">
+                                            <li>PerennialConInfo</li>
+                                            <p>The information about the series of conventions</p>
+                                        </xsl:if>
+                                        <xsl:if test="$editConInfo">
+                                            <li>ConInfo</li>
+                                            <p>The information about a specific convention</p>
+                                        </xsl:if>
+                                        <xsl:if test="$editConKeyDates">
+                                            <li>ConKeyDates</li>
+                                            <p>Dates sessions can be proposed for each division</p>
+                                        </xsl:if>
                                     </ul>
                                 </div>
                                 <xsl:if test="$editDivisions">
@@ -728,6 +767,15 @@
                                 </xsl:if>
                                 <xsl:if test="$editRegTypes">
                                     <div class="tab-pane mt-4 fade" id="regtypes"/>
+                                </xsl:if>
+                                <xsl:if test="$editPerennialConInfo">
+                                    <div class="tab-pane mt-4 fade" id="perennial_con_info"/>
+                                </xsl:if>
+                                <xsl:if test="$editConInfo">
+                                    <div class="tab-pane mt-4 fade" id="con_info"/>
+                                </xsl:if>
+                                <xsl:if test="$editConKeyDates">
+                                    <div class="tab-pane mt-4 fade" id="con_key_dates"/>
                                 </xsl:if>
                             </div>
                         </div>


### PR DESCRIPTION
This change adds the following tables to the Configuration Table Editor:
- perennial_con_info
- con_info
- con_key_dates

The change adds permission atoms for each table.

It also adds the display_order column to all three tables to enable editing.

Adds a foreign key to con_id on the con_key_dates table.