### PR TITLE
Don't display survey stuff if survey is off

### DIFF
--- a/webpages/InviteParticipants.php
+++ b/webpages/InviteParticipants.php
@@ -8,6 +8,8 @@ staff_header($title, $bootstrap4);
 $message = "";
 $alerttype = "success";
 $submittype = "";
+$SurveyUsed = USING_SURVEYS === TRUE ? TRUE : FALSE;
+
 if(may_I("Staff")) {
     $query = [];
     $query['participants'] = <<<EOD
@@ -45,15 +47,18 @@ SELECT
         T.trackname, S.sessionid, S.title;
 EOD;
 
-    // check for any survey stuff defined, before doing survey queries
-    $sql = "SELECT COUNT(*) AS questions FROM SurveyQuestionConfig WHERE searchable = 1;";
-    $result = mysqli_query_exit_on_error($sql);
-    $row = mysqli_fetch_assoc($result);
-    if ($row)
-        $SurveyUsed = $row["questions"]  > 0;
-    else
-        $SurveyUsed = false;
-    mysqli_free_result($result);
+    //if survey flag is turned on, then do a further check
+    if ($SurveyUsed) {
+        // check for any survey stuff defined, before doing survey queries
+        $sql = "SELECT COUNT(*) AS questions FROM SurveyQuestionConfig WHERE searchable = 1;";
+        $result = mysqli_query_exit_on_error($sql);
+        $row = mysqli_fetch_assoc($result);
+        if ($row)
+            $SurveyUsed = $row["questions"]  > 0;
+        else
+            $SurveyUsed = false;
+        mysqli_free_result($result);
+    }
 
     if ($SurveyUsed) {
         // get searchable survey response options


### PR DESCRIPTION
Check the USING_SURVEYS flag to see if it is TRUE and if it is not, then don't check survey tables. 
The issue is that if the surveys had been on to test it out, but then it was turned off, then the survey stuff was still being displayed on this page because there were entries in the survey questions table.