### PR TITLE
Fix ShowSessions page to not have multiple blank lines

### DIFF
--- a/webpages/render_functions.php
+++ b/webpages/render_functions.php
@@ -75,7 +75,20 @@ function RenderPrecisToString($result, $showlinks, $href, $sessionSearchArray, $
     while (list($sessionid, $trackname, $typename, $title, $duration, $estatten, $progguiddesc, $persppartinfo, $starttime, $roomname, $statusname, $taglist, $notesforprog, $notesforpart, $servicenotes, $pubstatusname, $sessionhistory)
         = mysqli_fetch_array($result, MYSQLI_NUM)) {
         $html .= "<tr>\n";
-        $rowSpan = $oneLinePerSession ? "" : "rowspan=\"3\"";
+        $rowSpanCnt = 3;
+        if ($persppartinfo) {
+          $rowSpanCnt++;
+        }
+        if ($notesforprog) {
+          $rowSpanCnt++;
+        }
+        if ($notesforpart) {
+          $rowSpanCnt++;
+        }
+        if ($servicenotes) {
+          $rowSpanCnt++;
+        }
+        $rowSpan = $oneLinePerSession ? "" : "rowspan=\"" . $rowSpanCnt . "\"";
         $html .= "  <th $rowSpan id=\"sessidtcell\">";
         if ($showlinks) {
             $html .= "<a href=\"StaffAssignParticipants.php?selsess=" . $sessionid . "\">" . $sessionid . "</a>";
@@ -144,7 +157,6 @@ function RenderPrecisToString($result, $showlinks, $href, $sessionSearchArray, $
         if ($notesforprog) {
             if (!$oneLinePerSession) {
                 $html .= "<tr>";
-                $html .= "<td></td>";
                 $html .= "<td $colSpan2>Notes for Programming Committee: </td>";
             }
             $html .= "<td $colSpan6>".htmlspecialchars($notesforprog,ENT_NOQUOTES)."</td>";
@@ -159,7 +171,6 @@ function RenderPrecisToString($result, $showlinks, $href, $sessionSearchArray, $
         if ($notesforpart) {
             if (!$oneLinePerSession) {
                 $html .= "<tr>";
-                $html .= "<td></td>";
                 $html .= "<td $colSpan2>Notes for Participants: </td>";
             }
             $html .= "<td $colSpan6>".htmlspecialchars($notesforpart,ENT_NOQUOTES)."</td>";
@@ -174,7 +185,6 @@ function RenderPrecisToString($result, $showlinks, $href, $sessionSearchArray, $
         if ($servicenotes) {
             if (!$oneLinePerSession) {
                 $html .= "<tr>";
-                $html .= "<td></td>";
                 $html .= "<td $colSpan2>Notes for Tech and Hotel: </td>";
             }
             $html .= "<td $colSpan6>".htmlspecialchars($servicenotes,ENT_NOQUOTES)."</td>";
@@ -189,7 +199,6 @@ function RenderPrecisToString($result, $showlinks, $href, $sessionSearchArray, $
         if ($sessionhistory) {
             if (!$oneLinePerSession) {
                 $html .= "<tr>";
-                $html .= "<td></td>";
                 $html .= "<td $colSpan2>Session History Notes: </td>";
             }
             $html .= "<td $colSpan6>".htmlspecialchars($sessionhistory,ENT_NOQUOTES)."</td>";

--- a/webpages/render_functions.php
+++ b/webpages/render_functions.php
@@ -130,7 +130,6 @@ function RenderPrecisToString($result, $showlinks, $href, $sessionSearchArray, $
         if ($persppartinfo) {
             if (!$oneLinePerSession) {
                 $html .= "<tr>";
-                $html .= "<td></td>";
                 $html .= "<td $colSpan2>Prospective Participant Info: </td>";
             }
             $html .= "<td $colSpan6>".htmlspecialchars($persppartinfo,ENT_NOQUOTES)."</td>";
@@ -138,12 +137,8 @@ function RenderPrecisToString($result, $showlinks, $href, $sessionSearchArray, $
                 $html .= "</tr>\n";
             }
         } else {
-            if (!$oneLinePerSession) {
-                $html .= "<tr>";
-            }
-            $html .= "<td $colSpan8>&nbsp;</td>\n";
-            if (!$oneLinePerSession) {
-                $html .= "</tr>\n";
+            if ($oneLinePerSession) {
+              $html .= "<td $colSpan8>&nbsp;</td>\n";
             }
         }
         if ($notesforprog) {
@@ -157,12 +152,8 @@ function RenderPrecisToString($result, $showlinks, $href, $sessionSearchArray, $
                 $html .= "</tr>\n";
             }
         } else {
-            if (!$oneLinePerSession) {
-                $html .= "<tr>";
-            }
-            $html .= "<td $colSpan8>&nbsp;</td>\n";
-            if (!$oneLinePerSession) {
-                $html .= "</tr>\n";
+            if ($oneLinePerSession) {
+                $html .= "<td $colSpan8>&nbsp;</td>\n";
             }
         }
         if ($notesforpart) {
@@ -176,12 +167,8 @@ function RenderPrecisToString($result, $showlinks, $href, $sessionSearchArray, $
                 $html .= "</tr>\n";
             }
         } else {
-            if (!$oneLinePerSession) {
-                $html .= "<tr>";
-            }
-            $html .= "<td $colSpan8>&nbsp;</td>\n";
-            if (!$oneLinePerSession) {
-                $html .= "</tr>\n";
+            if ($oneLinePerSession) {
+                $html .= "<td $colSpan8>&nbsp;</td>\n";
             }
         }
         if ($servicenotes) {
@@ -195,12 +182,8 @@ function RenderPrecisToString($result, $showlinks, $href, $sessionSearchArray, $
                 $html .= "</tr>\n";
             }
         } else {
-            if (!$oneLinePerSession) {
-                $html .= "<tr>";
-            }
-            $html .= "<td $colSpan8>&nbsp;</td>\n";
-            if (!$oneLinePerSession) {
-                $html .= "</tr>\n";
+            if ($oneLinePerSession) {
+                $html .= "<td $colSpan8>&nbsp;</td>\n";
             }
         }
         if ($sessionhistory) {
@@ -222,7 +205,9 @@ function RenderPrecisToString($result, $showlinks, $href, $sessionSearchArray, $
                 $html .= "</tr>\n";
             }
         }
-        echo "<tr><td colspan=\"8\" class=\"border0020\">&nbsp;</td></tr>\n";
+        if (!$oneLinePerSession) {
+            echo "<tr><td colspan=\"8\" class=\"border0020\">&nbsp;</td></tr>\n";
+        }
     }
     $html .= "</table>\n";
     $html .= "</div></div>";


### PR DESCRIPTION
The ShowSessions page was showing multiple blank lines when various fields were blank in the session detail. For example, if the Notes for Participants field was blank, a blank line was displaying. 
The fix is to not show a line if there is no data in the field.