### PR TITLE
Fix time format to use 24 hour format time

### DIFF
--- a/webpages/ConfigurationAdmin.php
+++ b/webpages/ConfigurationAdmin.php
@@ -195,7 +195,7 @@ function outputType(string $type, $value): string
     case 'int':
       return $value ?: '0';
     case 'datetime':
-      return "\"" . (new DateTime($value))->format("Y-m-d h:i:s") . "\"";
+      return "\"" . (new DateTime($value))->format("Y-m-d H:i:s") . "\"";
     default:
       return "\"". str_replace('"', '\"', $value) ."\"";
   }


### PR DESCRIPTION
The time on some fields was getting messed up because it was changing the SQL 24 hour format to an AM/PM format on my env and then would save it wrong.