### PR TITLE
Custom login

### DIFF
--- a/webpages/CommonCode.php
+++ b/webpages/CommonCode.php
@@ -4,7 +4,8 @@ require_once('error_functions.php');
 require_once('Constants.php');
 require_once('data_functions.php');
 require_once('db_functions.php');
-require_once('custom_functions.php');
+if (file_exists('custom_functions.php'))
+    include_once('custom_functions.php');
 require_once('render_functions.php');
 require_once('validation_functions.php');
 require_once('HtmlHeader.php');

--- a/webpages/CommonCode.php
+++ b/webpages/CommonCode.php
@@ -4,6 +4,7 @@ require_once('error_functions.php');
 require_once('Constants.php');
 require_once('data_functions.php');
 require_once('db_functions.php');
+require_once('custom_functions.php');
 require_once('render_functions.php');
 require_once('validation_functions.php');
 require_once('HtmlHeader.php');

--- a/webpages/CommonHeader.php
+++ b/webpages/CommonHeader.php
@@ -23,6 +23,7 @@ function commonHeader($headerVersion, $isLoggedIn, $noUserRequired, $loginPageSt
     $paramArray["no_user_required"] = $noUserRequired;
     $paramArray["RESET_PASSWORD_SELF"] = RESET_PASSWORD_SELF;
     $paramArray["PUBLIC_NEW_USER"] = PUBLIC_NEW_USER;
+    $paramArray["LOGIN_PHP"] = defined('CUSTOM_LOGIN_PHP') ? CUSTOM_LOGIN_PHP : 'doLogin.php';
     if ($bootstrap4) {
         RenderXSLT('GlobalHeader_BS4.xsl', $paramArray);
     } else {

--- a/webpages/CommonHeader.php
+++ b/webpages/CommonHeader.php
@@ -23,7 +23,7 @@ function commonHeader($headerVersion, $isLoggedIn, $noUserRequired, $loginPageSt
     $paramArray["no_user_required"] = $noUserRequired;
     $paramArray["RESET_PASSWORD_SELF"] = RESET_PASSWORD_SELF;
     $paramArray["PUBLIC_NEW_USER"] = PUBLIC_NEW_USER;
-    $paramArray["LOGIN_PHP"] = defined('CUSTOM_LOGIN_PHP') ? CUSTOM_LOGIN_PHP : 'doLogin.php';
+    $paramArray["LOGIN_PHP"] = defined('CUSTOM_LOGIN_PHP') && !empty(CUSTOM_LOGIN_PHP) ? CUSTOM_LOGIN_PHP : 'doLogin.php';
     if ($bootstrap4) {
         RenderXSLT('GlobalHeader_BS4.xsl', $paramArray);
     } else {

--- a/webpages/config/db_env_sample.php
+++ b/webpages/config/db_env_sample.php
@@ -28,6 +28,7 @@ define("ROOT_URL", 'https://' . getenv("HOSTNAME") . '/'); // URL to reach this 
 
 define("ENCRYPT_KEY", ""); // used for encrypting hidden inputs; I suggest finding a random password generator and putting in a 64 character alphanumeric only password
 
+define("CUSTOM_LOGIN_PHP", ""); // Custom login function connected to reg system
 
 
 ?>

--- a/webpages/config/db_name_sample.php
+++ b/webpages/config/db_name_sample.php
@@ -126,7 +126,6 @@ define("PUBLIC_NEW_USER", FALSE); // allow new user creation from login screen
 
 define("CONFIRM_SESSION_ASSIGNMENT", TRUE); // Ask participants to confirm their assignments
 
-define("USE_CUSTOM_REG_SYSTEM", FALSE); // Define DB Connection to Registration Database.
 define("CUSTOM_LOGIN_PHP", ""); // Custom login function connected to reg system
 
 ?>

--- a/webpages/config/db_name_sample.php
+++ b/webpages/config/db_name_sample.php
@@ -126,6 +126,5 @@ define("PUBLIC_NEW_USER", FALSE); // allow new user creation from login screen
 
 define("CONFIRM_SESSION_ASSIGNMENT", TRUE); // Ask participants to confirm their assignments
 
-define("CUSTOM_LOGIN_PHP", ""); // Custom login function connected to reg system
 
 ?>

--- a/webpages/config/db_name_sample.php
+++ b/webpages/config/db_name_sample.php
@@ -125,4 +125,8 @@ define("REPORT_INCLUDE_DIRECTORY", "/var/data/planz/");  // outside of web serve
 define("PUBLIC_NEW_USER", FALSE); // allow new user creation from login screen
 
 define("CONFIRM_SESSION_ASSIGNMENT", TRUE); // Ask participants to confirm their assignments
+
+define("USE_CUSTOM_REG_SYSTEM", FALSE); // Define DB Connection to Registration Database.
+define("CUSTOM_LOGIN_PHP", ""); // Custom login function connected to reg system
+
 ?>

--- a/webpages/custom_functions.php
+++ b/webpages/custom_functions.php
@@ -1,7 +1,0 @@
-<?php
-// Empty routine to allow groups to add custom functions for their event.
-
-
-
-
-?>

--- a/webpages/custom_functions.php
+++ b/webpages/custom_functions.php
@@ -1,0 +1,7 @@
+<?php
+// Empty routine to allow groups to add custom functions for their event.
+
+
+
+
+?>

--- a/webpages/db_functions.php
+++ b/webpages/db_functions.php
@@ -271,6 +271,9 @@ if( file_exists( './config/db_name.php' ) ) {
 } else {
     echo '<strong>FATAL ERROR: Config file not found.</strong><br />';
 }
+if (USE_REG_SYSTEM === TRUE) {
+    require_once ('./custom_reg.php'); // Calls an extra file which contains authentication methods for interfacing with con Registration.
+}
 
 
 function prepare_db_and_more() {
@@ -900,6 +903,11 @@ function isLoggedIn() {
         return false;
     }
 
+    if (USE_REG_SYSTEM === TRUE) {
+        global $reg_link;
+        return custom_isLoggedIn();
+    }
+
     $query = "SELECT password FROM Participants WHERE badgeid = '{$_SESSION['badgeid']}';";
     if (!$result = mysqli_query_with_error_handling($query)) {
         unset($_SESSION['badgeid']);
@@ -1133,6 +1141,5 @@ function survey_programmed() {
            return $questions > 0;
     return false;
 }
-
 
 ?>

--- a/webpages/xsl/GlobalHeader.xsl
+++ b/webpages/xsl/GlobalHeader.xsl
@@ -13,6 +13,7 @@
     <xsl:param name="header_error_message" select="''" />
     <xsl:param name="RESET_PASSWORD_SELF" select="true()" /><!-- TRUE/FALSE -->
     <xsl:param name="PUBLIC_NEW_USER" select="false()" /><!-- TRUE/FALSE -->
+    <xsl:param name="LOGIN_PHP" select="'doLogin.php'" />
     <xsl:template match="/">
         <header class="header-wrapper" data-pbo="GlobalHeader.xsl:14">
             <div id="reg-header-container" class="collapsible-wrapper">
@@ -62,7 +63,7 @@
                         </xsl:when>
                         <xsl:when test="not($no_user_required)">
                             <div>
-                                <form id="login-form" name="loginform" class="form-horizontal" method="post" action="doLogin.php" data-pbo="GlobalHeader.xsl:59">
+                                <form id="login-form" name="loginform" class="form-horizontal" method="post" action="{$LOGIN_PHP}" data-pbo="GlobalHeader.xsl:59">
                                     <fieldset id="login-box">
                                         <xsl:choose>
                                             <xsl:when test="$login_page_status='Normal'">

--- a/webpages/xsl/GlobalHeader_BS4.xsl
+++ b/webpages/xsl/GlobalHeader_BS4.xsl
@@ -14,6 +14,7 @@
     <xsl:param name="header_error_message" select="''" />
     <xsl:param name="RESET_PASSWORD_SELF" select="true()" /><!-- TRUE/FALSE -->
     <xsl:param name="PUBLIC_NEW_USER" select="false()" /><!-- TRUE/FALSE -->
+    <xsl:param name="LOGIN_PHP" select="'doLogin.php'" />
     <xsl:template match="/">
         <header class="header-wrapper" data-pbo="GlobalHeader_BS4.xsl:15">
             <div id="reg-header-container" class="collapsible-wrapper">
@@ -136,7 +137,7 @@
                     </div>
                     <div class="card-body">
                         <div class="row">
-                        <form id="login-form" class="col-md-6" name="loginform" method="post" action="doLogin.php" data-pbo="GlobalHeader_BS4.xsl:60">
+                        <form id="login-form" class="col-md-6" name="loginform" method="post" action="{$LOGIN_PHP}" data-pbo="GlobalHeader_BS4.xsl:60">
                             <fieldset id="login-box mt-3">
                                 <div class="form-group">
                                     <label for="badgeid" class="sr-only"><xsl:value-of select="$USER_ID_PROMPT" /></label>


### PR DESCRIPTION
Add code to allow a custom login method.

PlanZ for Capricon is set up to allow people to login using their Capricon account that is set up by Capricon's registration. This means that code to connect to the reg system needs to be called.

I wanted to abstract this out a bit so that other groups could do something similar using their own system.
