### PR TITLE
Missing comma in insert statement.

### DIFF
--- a/Install/Upgrade_dbase/63_add_permission.sql
+++ b/Install/Upgrade_dbase/63_add_permission.sql
@@ -7,6 +7,6 @@
 
 
 INSERT INTO Permissions(permatomid, phaseid, permroleid, badgeid)
-VALUES (2, NULL, 1 NULL);
+VALUES (2, NULL, 1, NULL);
 
 INSERT INTO PatchLog (patchname) VALUES ('63_add_permission.sql');


### PR DESCRIPTION
Very small change to DB update 63.
Was updating an old database and I ran into an error in the update script.
Probably won't affect most people, but thought I'd correct.