### PR TITLE
Add an Expand All button to the participant session search results page

### DIFF
--- a/webpages/PartSearchSessionsSubmit.php
+++ b/webpages/PartSearchSessionsSubmit.php
@@ -95,13 +95,25 @@ EOD;
 if (($resultXML = mysql_query_XML($queryArray)) === false) {
     RenderError($message_error);
     exit();
-    }
+}
+
+//Run the sessions query to get session ids for the multi collapse class
+if (!$result = mysqli_query_exit_on_error($queryArray["sessions"])) {
+    exit(); // Should have exited already
+}
+$collapse_list = '';
+while ($row = mysqli_fetch_assoc($result)) {
+    $collapse_list .= 'collapse-$row["sessionid"] ';
+}
+
 $paramArray = array();
 $paramArray['may_I'] = may_I('my_panel_interests') ? "1" : "0";
 $paramArray['conName'] = CON_NAME;
 $paramArray["trackIsPrimary"] = TRACK_TAG_USAGE === "TRACK_ONLY" || TRACK_TAG_USAGE === "TRACK_OVER_TAG";
 $paramArray["showTrack"] = TRACK_TAG_USAGE !== "TAG_ONLY";
 $paramArray["showTags"] = TRACK_TAG_USAGE !== "TRACK_ONLY";
+$paramArray["collapse_list"] = $collapse_list;
+
 participant_header($title, false, 'Normal', true);
 echo(mb_ereg_replace("<(row|query)([^>]*/[ ]*)>", "<\\1\\2></\\1>", $resultXML->saveXML(), "i")); //for debugging only
 RenderXSLT('PartSearchSessionsSubmit.xsl', $paramArray, $resultXML);

--- a/webpages/xsl/PartSearchSessionsSubmit.xsl
+++ b/webpages/xsl/PartSearchSessionsSubmit.xsl
@@ -11,6 +11,7 @@
     <xsl:param name="trackIsPrimary" />
     <xsl:param name="showTrack" />
     <xsl:param name="showTags" />
+    <xsl:param name="collapse_list" />
     <xsl:variable name="interested" select="/doc/query[@queryName='interested']/row/@interested='1'"/>
     <xsl:variable name="mayISubmitPanelInterests" select="$interested and $may_I" />
 
@@ -50,6 +51,11 @@
                                 <xsl:if test="not($mayISubmitPanelInterests)"><xsl:attribute name="disabled">disabled</xsl:attribute></xsl:if>
                                 <xsl:text>Save</xsl:text>
                             </button>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-sm-2 offset-sm-10 float-right">
+                            <a class="btn btn-info" data-toggle="collapse" href=".multi-collapse" role="button" aria-expanded="false" aria-controls="{$collapse_list}">Expand All</a>
                         </div>
                     </div>
                     <hr />
@@ -189,7 +195,7 @@
                     </xsl:otherwise>
                 </xsl:choose>
             </div>
-            <div id="collapse-{@sessionid}" class="collapse list-group list-group-flush">
+            <div id="collapse-{@sessionid}" class="collapse multi-collapse list-group list-group-flush">
                 <div class="list-group-item py-1">
                     <div class="row">
                         <div class="col-0p75 pl-1 pr-0">Duration:</div>


### PR DESCRIPTION
Adds an Expand All button that will toggle the expand of the session details on the participant session search results page.

![image](https://user-images.githubusercontent.com/25570607/200098681-afc1de62-22fc-442e-822e-e6f84d2f26e7.png)
