### PR TITLE
make volunteer shifts con-specific

### DIFF
--- a/Install/Upgrade_dbase/89ZED_volunteer_to_con_info.sql
+++ b/Install/Upgrade_dbase/89ZED_volunteer_to_con_info.sql
@@ -1,0 +1,14 @@
+##
+## Make volunteer shifts con-specific
+##
+## Created by BC Holmes
+##
+
+alter table volunteer_shift add column con_id int(11);
+
+update volunteer_shift set con_id = (select max(id) from current_con) where con_id is null;
+
+alter table volunteer_shift modify con_id int(11) not null;
+alter table volunteer_shift add CONSTRAINT `fk_volunteer_shift_con_id` FOREIGN KEY (`con_id`) REFERENCES `con_info` (`id`);
+
+INSERT INTO PatchLog (patchname) VALUES ('89ZED_volunteer_to_con_info.sql');

--- a/webpages/api/volunteer/get_volunteer_shifts.php
+++ b/webpages/api/volunteer/get_volunteer_shifts.php
@@ -5,6 +5,7 @@
 if (!include ('../../config/db_name.php')) {
     include ('../../config/db_name.php');
 }
+require_once('../con_info.php');
 require_once('../http_session_functions.php');
 require_once('../../db_exceptions.php');
 require_once('../db_support_functions.php');
@@ -37,8 +38,12 @@ start_session_if_necessary();
 $db = connect_to_db(true);
 $authentication = new Authentication();
 try {
-    if ($_SERVER['REQUEST_METHOD'] === 'GET' && $authentication->isLoggedIn()) {
-        $shifts = VolunteerShift::findAll($db);
+    $conInfo = ConInfo::findCurrentCon($db);
+
+    if ($conInfo == null) {
+        http_response_code(409);
+    } else if ($_SERVER['REQUEST_METHOD'] === 'GET' && $authentication->isLoggedIn()) {
+        $shifts = VolunteerShift::findAll($db, $conInfo);
         $result = [];
         foreach ($shifts as $s) {
             $result[] = $s->asArray();

--- a/webpages/reports/volunteersignup.php
+++ b/webpages/reports/volunteersignup.php
@@ -30,7 +30,8 @@ SELECT
          JOIN volunteer_job VJ ON (VS.volunteer_job_id = VJ.id)
     LEFT JOIN participant_has_volunteer_shift PHVS ON (PHVS.volunteer_shift_id = VS.id)
     LEFT JOIN CongoDump CD ON (PHVS.badgeid = CD.badgeid)
-    LEFT JOIN Participants P ON (PHVS.badgeid = P.badgeid);
+    LEFT JOIN Participants P ON (PHVS.badgeid = P.badgeid)
+    WHERE VS.con_id in (select id from current_con);
 EOD;
 $report['xsl'] =<<<'EOD'
 <?xml version="1.0" encoding="UTF-8" ?>


### PR DESCRIPTION
Volunteer shifts are, of course, very con-specific (i.e.: people sign up for a shift at this year's con; that doesn't mean that they also volunteer for the same shift the next year). Conveniently, the volunteer shift table includes a full date (rather than, for example, the Session practice of specifying a time offset). But to make it easier to clearly specify a particular con, I've now linked the volunteer_shift table with the con_info table.

One consequence of this change is that the con_info table must be populated to use volunteer shifts.

This is an exclusively server-side with changes in:

- the database;
- the volunteer REST API implementation; and
- the volunteer report.