### PR TITLE
Personal detail config

### DIFF
--- a/Install/Upgrade_dbase/92ZED_personal_details_custom_text.sql
+++ b/Install/Upgrade_dbase/92ZED_personal_details_custom_text.sql
@@ -1,0 +1,10 @@
+## This script adds a  CustomText entry for the Personal Details page.
+##
+##  Created by James Shields on 2023-02-01
+##
+
+INSERT INTO `CustomText` (`page`, `tag`, `textcontents`) VALUES 
+('Personal Details', 'personal_details_intro', '<p>We are committed to diverse panelist representation on our program items. To help us do that, please consider filling in the following OPTIONAL items of demographic information. All answers will be kept strictly confidential.</p>');
+
+
+INSERT INTO PatchLog (patchname) VALUES ('92ZED_personal_details_custom_text.sql');

--- a/webpages/config/db_name_sample.php
+++ b/webpages/config/db_name_sample.php
@@ -78,7 +78,22 @@ define("REGISTRATION_URL", "");
 define("USE_REGTYPE_DESCRIPTION", FALSE);
         // False -> Display regtype field as registration type - name of registration type in regtype.
         // True -> Display RegTypes.message - registration type code in regtype, description in message field.
+
+define("USE_DAY_JOB", TRUE); // let participants specify their daytime occupation
+define("LABEL_DAY_JOB", "Day Job:"); // Label for daytime occupation.
+define("USE_AGE_RANGE", TRUE); // let participants specify their age group
+define('LABEL_AGE_RANGE', "Age Range:"); // Label for age group
+define("USE_ETHNICITY", TRUE); // let participants specify their ethnicity
+define('LABEL_ETHNICITY', "Race/Ethnicity:"); // Label for ethnicity
+define("USE_ACCESSIBILITY", TRUE); // let participants specify their accessibility issues
+define('LABEL_ACCESSIBILITY', "Do you have any accessibility issues that we should be aware of?"); // Label for accessibility issues
+define("USE_GENDER", TRUE); // let participants specify their gender
+define('LABEL_GENDER', "Gender:"); // Label for gender
+define("USE_SEXUAL_ORIENTATION", TRUE); // let participants specify their sexual orientation
+define('LABEL_SEXUAL_ORIENTATION', "Sexual Orientation:"); // Label for sexual orientation
 define("USE_PRONOUNS", TRUE); // let participants specify their pronouns
+define("LABEL_PRONOUNS_ARE", "My pronouns are:"); // Label for pronouns drop-down.
+define("LABEL_PRONOUNS_OTHER", "If you selected \"other\" for your pronouns, provide your pronouns here:"); // Label for "other" pronouns.
 define("REG_PART_PREFIX", ""); // only needed for USE_REG_SYSTEM = FALSE; prefix portion of userid/badgeid before counter; can be empty string for no prefix
 define("REG_PART_DIGITS", 4); // only needed for USE_REG_SYSTEM = FALSE; number of digits to pad counter; if number has fewer than specified digits, will left pad with zeros
 define("HTML_BIO", TRUE); // Allow editing BIO as HTML and saving it both as plain text and HTML

--- a/webpages/config/db_name_sample.php
+++ b/webpages/config/db_name_sample.php
@@ -79,19 +79,19 @@ define("USE_REGTYPE_DESCRIPTION", FALSE);
         // False -> Display regtype field as registration type - name of registration type in regtype.
         // True -> Display RegTypes.message - registration type code in regtype, description in message field.
 
-define("USE_DAY_JOB", TRUE); // let participants specify their daytime occupation
+define("USE_DAY_JOB", TRUE); // Let participants specify their daytime occupation on Personal Details page.
 define("LABEL_DAY_JOB", "Day Job:"); // Label for daytime occupation.
-define("USE_AGE_RANGE", TRUE); // let participants specify their age group
-define('LABEL_AGE_RANGE', "Age Range:"); // Label for age group
-define("USE_ETHNICITY", TRUE); // let participants specify their ethnicity
-define('LABEL_ETHNICITY', "Race/Ethnicity:"); // Label for ethnicity
-define("USE_ACCESSIBILITY", TRUE); // let participants specify their accessibility issues
-define('LABEL_ACCESSIBILITY', "Do you have any accessibility issues that we should be aware of?"); // Label for accessibility issues
-define("USE_GENDER", TRUE); // let participants specify their gender
-define('LABEL_GENDER', "Gender:"); // Label for gender
-define("USE_SEXUAL_ORIENTATION", TRUE); // let participants specify their sexual orientation
-define('LABEL_SEXUAL_ORIENTATION', "Sexual Orientation:"); // Label for sexual orientation
-define("USE_PRONOUNS", TRUE); // let participants specify their pronouns
+define("USE_AGE_RANGE", TRUE); // Let participants specify their age group.
+define('LABEL_AGE_RANGE', "Age Range:"); // Label for age group.
+define("USE_ETHNICITY", TRUE); // Let participants specify their ethnicity.
+define('LABEL_ETHNICITY', "Race/Ethnicity:"); // Label for ethnicity.
+define("USE_ACCESSIBILITY", TRUE); // Let participants specify their accessibility issues.
+define('LABEL_ACCESSIBILITY', "Do you have any accessibility issues that we should be aware of?"); // Label for accessibility issues.
+define("USE_GENDER", TRUE); // Let participants specify their gender.
+define('LABEL_GENDER', "Gender:"); // Label for gender on Personal Details page.
+define("USE_SEXUAL_ORIENTATION", TRUE); // Let participants specify their sexual orientation.
+define('LABEL_SEXUAL_ORIENTATION', "Sexual Orientation:"); // Label for sexual orientation.
+define("USE_PRONOUNS", TRUE); // Let participants specify their pronouns on Personal Details page.
 define("LABEL_PRONOUNS_ARE", "My pronouns are:"); // Label for pronouns drop-down.
 define("LABEL_PRONOUNS_OTHER", "If you selected \"other\" for your pronouns, provide your pronouns here:"); // Label for "other" pronouns.
 define("REG_PART_PREFIX", ""); // only needed for USE_REG_SYSTEM = FALSE; prefix portion of userid/badgeid before counter; can be empty string for no prefix

--- a/webpages/my_details.php
+++ b/webpages/my_details.php
@@ -1,7 +1,7 @@
 <?php
 // Copyright (c) 2019-2022 Leane Verhulst. All rights reserved. See copyright document for more details.
 
-global $linki, $participant, $message_error, $message2, $congoinfo;
+global $linki, $badgeid, $participant, $message_error, $message2, $congoinfo;
 $title = "Personal Details";
 require('PartCommonCode.php'); // initialize db; check login;
 require_once('ParticipantHeader.php');

--- a/webpages/my_details.php
+++ b/webpages/my_details.php
@@ -6,6 +6,7 @@ $title = "Personal Details";
 require('PartCommonCode.php'); // initialize db; check login;
 require_once('ParticipantHeader.php');
 require_once('renderMyDetails.php');
+populateCustomTextArray();
 // set $badgeid from session
 $query = <<<EOB
 SELECT

--- a/webpages/renderMyDetails.php
+++ b/webpages/renderMyDetails.php
@@ -33,111 +33,137 @@ function renderMyDetails ($title, $error, $message, $dayjob, $accessibilityissue
 
     echo "        <div class=\"row\">\n";  //first row
 
-    echo "            <div class=\"col-auto\">\n";
-    echo "                <label for=\"dayjob\">Day Job: </label>\n";
-    echo "            </div>\n";
-    echo "            <div class=\"col-auto\">\n";
-    echo "                <input type=\"text\" size=\"20\" class=\"form-control\" name=\"dayjob\" value=\"" . htmlspecialchars($dayjob, ENT_COMPAT) . "\"";
-    if (!may_I('my_gen_int_write')) {
-        echo " readonly class=\"readonly\"";
+    if (defined('USE_DAY_JOB') && USE_DAY_JOB) {
+        if (!defined('LABEL_DAY_JOB'))
+            define ('LABEL_DAY_JOB', "Day Job:");
+        echo "            <div class=\"col-auto\">\n";
+        echo "                <label for=\"dayjob\">" .  LABEL_DAY_JOB . " </label>\n";
+        echo "            </div>\n";
+        echo "            <div class=\"col-auto\">\n";
+        echo "                <input type=\"text\" size=\"20\" class=\"form-control\" name=\"dayjob\" value=\"" . htmlspecialchars($dayjob, ENT_COMPAT) . "\"";
+        if (!may_I('my_gen_int_write')) {
+            echo " readonly class=\"readonly\"";
+        }
+        echo ">\n";
+        echo "            </div>\n";
     }
-    echo ">\n";
-    echo "            </div>\n";
 
-    echo "            <div class=\"col-auto\">\n";
-    echo "                <label for=\"agerangeid\">Age Range: </label>\n";
-    echo "            </div>\n";
-    echo "            <div class=\"col-auto\">\n";
-    echo "                <select name=\"agerangeid\" class=\"form-control\">\n";
-    populate_select_from_table("AgeRanges", $agerangeid, "", false);
-    echo "                </select>\n";
-    echo "            </div>\n";
-
-    echo "            <div class=\"col-auto\">\n";
-    echo "                <label for=\"ethnicity\">Race/Ethnicity: </label>\n";
-    echo "            </div>\n";
-    echo "            <div class=\"col-auto\">\n";
-    echo "                <input type=\"text\" size=\"20\" class=\"form-control\" name=\"ethnicity\" value=\"" . htmlspecialchars($ethnicity, ENT_COMPAT) . "\"";
-    if (!may_I('my_gen_int_write')) {
-        echo " readonly class=\"readonly\"";
+    if (defined('USE_AGE_RANGE') && USE_AGE_RANGE) {
+        if (!defined('LABEL_AGE_RANGE'))
+            define('LABEL_AGE_RANGE', "Age Range:");
+        echo "            <div class=\"col-auto\">\n";
+        echo "                <label for=\"agerangeid\">" . LABEL_AGE_RANGE . " </label>\n";
+        echo "            </div>\n";
+        echo "            <div class=\"col-auto\">\n";
+        echo "                <select name=\"agerangeid\" class=\"form-control\">\n";
+        populate_select_from_table("AgeRanges", $agerangeid, "", false);
+        echo "                </select>\n";
+        echo "            </div>\n";
     }
-    echo ">\n";
-    echo "            </div>\n";
 
+    if (defined('USE_ETHNICITY') && USE_ETHNICITY) {
+        if (!defined('LABEL_ETHNICITY'))
+            define('LABEL_ETHNICITY', "Race/Ethnicity:");
+        echo "            <div class=\"col-auto\">\n";
+        echo "                <label for=\"ethnicity\">" . LABEL_ETHNICITY . " </label>\n";
+        echo "            </div>\n";
+        echo "            <div class=\"col-auto\">\n";
+        echo "                <input type=\"text\" size=\"20\" class=\"form-control\" name=\"ethnicity\" value=\"" . htmlspecialchars($ethnicity, ENT_COMPAT) . "\"";
+        if (!may_I('my_gen_int_write')) {
+            echo " readonly class=\"readonly\"";
+        }
+        echo ">\n";
+        echo "            </div>\n";
+    }
     echo "        </div>\n";   //end of top row
 
 
+    if (defined('USE_ACCESSIBILITY') && USE_ACCESSIBILITY) {
+        if (!defined('LABEL_ACCESSIBILITY'))
+            define('LABEL_ACCESSIBILITY', "Do you have any accessibility issues that we should be aware of?");
 
-    echo "        <div class=\"row mt-3\">\n";    //second row
+        echo "        <div class=\"row mt-3\">\n"; //second row
 
-    echo "            <div class=\"col-12\">\n";
-    echo "                <label for=\"accessibilityissues\">Do you have any accessibility issues that we should be aware of?</label>\n";
-    echo "                <textarea class=\"form-control\" name=\"accessibilityissues\" rows=5";
-    if (!may_I('my_gen_int_write')) {
-        echo " readonly class=\"readonly\"";
+        echo "            <div class=\"col-12\">\n";
+        echo "                <label for=\"accessibilityissues\">" . LABEL_ACCESSIBILITY . "</label>\n";
+        echo "                <textarea class=\"form-control\" name=\"accessibilityissues\" rows=5";
+        if (!may_I('my_gen_int_write')) {
+            echo " readonly class=\"readonly\"";
+        }
+        echo ">" . htmlspecialchars($accessibilityissues, ENT_COMPAT) . "</textarea>\n";
+        echo "            </div>\n";
+
+        echo "        </div>\n"; //end of second row
     }
-    echo ">" . htmlspecialchars($accessibilityissues, ENT_COMPAT) . "</textarea>\n";
-    echo "            </div>\n";
-
-    echo "        </div>\n";    //end of second row
-
 
     echo "        <div class=\"row mt-3\">\n";    //third row
 
-    echo "            <div class=\"col-auto\">\n";
-    echo "                <label for=\"gender\">Gender: </label>\n";
-    echo "            </div>\n";
-    echo "            <div class=\"col-auto\">\n";
-    echo "                <input type=\"text\" size=\"20\" class=\"form-control\" name=\"gender\" value=\"" . htmlspecialchars($gender, ENT_COMPAT) . "\"";
-    if (!may_I('my_gen_int_write')) {
-        echo " readonly class=\"readonly\"";
+    if (defined('USE_GENDER') && USE_GENDER) {
+        if (!defined('LABEL_GENDER'))
+            define('LABEL_GENDER', "Gender:");
+        echo "            <div class=\"col-auto\">\n";
+        echo "                <label for=\"gender\">" . LABEL_GENDER . " </label>\n";
+        echo "            </div>\n";
+        echo "            <div class=\"col-auto\">\n";
+        echo "                <input type=\"text\" size=\"20\" class=\"form-control\" name=\"gender\" value=\"" . htmlspecialchars($gender, ENT_COMPAT) . "\"";
+        if (!may_I('my_gen_int_write')) {
+            echo " readonly class=\"readonly\"";
+        }
+        echo ">\n";
+        echo "            </div>\n";
     }
-    echo ">\n";
-    echo "            </div>\n";
 
-    echo "            <div class=\"col-auto\">\n";
-    echo "                <label for=\"sexualorientation\">Sexual Orientation: </label>\n";
-    echo "            </div>\n";
-    echo "            <div class=\"col-auto\">\n";
-    echo "                <input type=\"text\" size=\"20\" class=\"form-control\" name=\"sexualorientation\" value=\"" . htmlspecialchars($sexualorientation, ENT_COMPAT) . "\"";
-    if (!may_I('my_gen_int_write')) {
-        echo " readonly class=\"readonly\"";
+    if (defined('USE_SEXUAL_ORIENTATION') && USE_SEXUAL_ORIENTATION) {
+        if (!defined('LABEL_SEXUAL_ORIENTATION'))
+            define('LABEL_SEXUAL_ORIENTATION', "Sexual Orientation:");
+        echo "            <div class=\"col-auto\">\n";
+        echo "                <label for=\"sexualorientation\">" . LABEL_SEXUAL_ORIENTATION . " </label>\n";
+        echo "            </div>\n";
+        echo "            <div class=\"col-auto\">\n";
+        echo "                <input type=\"text\" size=\"20\" class=\"form-control\" name=\"sexualorientation\" value=\"" . htmlspecialchars($sexualorientation, ENT_COMPAT) . "\"";
+        if (!may_I('my_gen_int_write')) {
+            echo " readonly class=\"readonly\"";
+        }
+        echo ">\n";
+        echo "            </div>\n";
     }
-    echo ">\n";
-    echo "            </div>\n"; 
 
     echo "        </div>\n";   //end of third row
 
+    if (defined('USE_PRONOUNS') && USE_PRONOUNS) {
+        if (!defined('LABEL_PRONOUNS_ARE'))
+            define('LABEL_PRONOUNS_ARE', "My pronouns are:");
+        if (!defined('LABEL_PRONOUNS_OTHER'))
+            define('LABEL_PRONOUNS_OTHER', "If you selected \"other\" for your pronouns, provide your pronouns here:");
+        echo "        <div class=\"row mt-3\">\n"; //fourth row
 
-    echo "        <div class=\"row mt-3\">\n";    //fourth row
+        echo "            <div class=\"col-auto\">\n";
+        echo "                <label for=\"pronounid\">" . LABEL_PRONOUNS_ARE . " </label>\n";
+        echo "            </div>\n";
+        echo "            <div class=\"col-auto\">\n";
+        echo "                <select name=\"pronounid\" class=\"form-control\">\n";
+        populate_select_from_table("Pronouns", $pronounid, "", false);
+        echo "                </select>\n";
+        echo "            </div>\n";
 
-    echo "            <div class=\"col-auto\">\n";
-    echo "                <label for=\"pronounid\">My pronouns are: </label>\n";
-    echo "            </div>\n";
-    echo "            <div class=\"col-auto\">\n";
-    echo "                <select name=\"pronounid\" class=\"form-control\">\n";
-    populate_select_from_table("Pronouns", $pronounid, "", false);
-    echo "                </select>\n";
-    echo "            </div>\n";
-
-    echo "        </div>\n";    //end of fourth row
+        echo "        </div>\n"; //end of fourth row
 
 
-    echo "        <div class=\"row mt-3\">\n";    //fifth row
+        echo "        <div class=\"row mt-3\">\n"; //fifth row
 
-    echo "            <div class=\"col-auto\">\n";
-    echo "                <label for=\"pronounother\">If you selected \"other\" for your pronouns, provide your pronouns here: </label>\n";
-    echo "            </div>\n";
-    echo "            <div class=\"col-auto\">\n";
-    echo "                <input type=\"text\" size=\"20\" class=\"form-control\" name=\"pronounother\" value=\"" . htmlspecialchars($pronounother, ENT_COMPAT) . "\"";
-    if (!may_I('my_gen_int_write')) {
-        echo " readonly class=\"readonly\"";
+        echo "            <div class=\"col-auto\">\n";
+        echo "                <label for=\"pronounother\">" . LABEL_PRONOUNS_OTHER . " </label>\n";
+        echo "            </div>\n";
+        echo "            <div class=\"col-auto\">\n";
+        echo "                <input type=\"text\" size=\"20\" class=\"form-control\" name=\"pronounother\" value=\"" . htmlspecialchars($pronounother, ENT_COMPAT) . "\"";
+        if (!may_I('my_gen_int_write')) {
+            echo " readonly class=\"readonly\"";
+        }
+        echo ">\n";
+        echo "            </div>\n";
+
+        echo "        </div>\n"; //end of fifth row
     }
-    echo ">\n";
-    echo "            </div>\n";
-
-    echo "        </div>\n";    //end of fifth row
-
 
     if (may_I('my_gen_int_write')) {
         echo "<div id=\"submit\"><button class=\"SubmitButton btn btn-primary\" type=\"submit\" name=\"submit\">Save</button></div>\n";

--- a/webpages/renderMyDetails.php
+++ b/webpages/renderMyDetails.php
@@ -4,7 +4,7 @@
 function renderMyDetails ($title, $error, $message, $dayjob, $accessibilityissues, $ethnicity, $gender, $sexualorientation, $agerangeid, $pronounid, $pronounother) {
 
     participant_header($title, false, 'Normal', true);
-
+    
     echo("<div class=\"container mt-2\">");
 
     if ($error) {
@@ -21,8 +21,7 @@ function renderMyDetails ($title, $error, $message, $dayjob, $accessibilityissue
     echo "<h5>" . CON_NAME . " Optional Demographic Details</h5>\n";
     echo "</div>";
     echo "<div class=\"card-body\">";
-    echo CON_NAME;
-    echo " is committed to diverse panelist representation on our program items. To help us do that, please consider filling in the following OPTIONAL items of demographic information. All answers will be kept strictly confidential.";
+    echo fetchCustomText('personal_details_intro');
     echo "</div>";
     echo "</div>";
 


### PR DESCRIPTION
Some of the questions on the Personal Information page may request information that some conventions don't require, or may not be legally able to hold.  Conventions in Europe are subject to GDPR regulations, and many other countries have similar laws.

This change is to allow conventions to remove questions that are not required/allowed from the Personal Details page.

There was an existing USE_PRONOUNS flag in the db_name file (although it doesn't appear to have been used since the pronouns were moved off the . I have added the following additional config settings:

- USE_DAY_JOB
- USE_AGE_RANGE
- USE_ETHNICITY
- USE_ACCESSIBILITY
- USE_GENDER
- USE_SEXUAL_ORIENTATION

The wording of questions on this page can also be sensitive, so conventions may want to tweak to meet their precise needs. I have added configuration settings for the labels. If we ever want to make labels customisable generally, I think we should look for a better general solution, but I think this page is a special case. The config settings are:

- LABEL_DAY_JOB
- LABEL_AGE_RANGE
- LABEL_ETHNICITY
- LABEL_ACCESSIBILITY
- LABEL_GENDER
- LABEL_SEXUAL_ORIENTATION
- LABEL_PRONOUNS_ARE
- LABEL_PRONOUNS_OTHER

Finally, I have added the intro text for the Personal Details page to the CustomText table to allow it to be edited.