### PR TITLE
create tool to assign session numbers to sessions

### DIFF
--- a/Install/Upgrade_dbase/94ZED_session_number_module.sql
+++ b/Install/Upgrade_dbase/94ZED_session_number_module.sql
@@ -1,0 +1,14 @@
+##
+## Some cons want to assign simple session numbers to their
+## sessions, so the first session of the con is number 1, etc.
+##
+## Created by BC Holmes
+##
+
+INSERT INTO `module`
+(`name`, `package_name`, `description`, `is_enabled`)
+values
+('Assign Session Numbers', 'planz.session_number',
+'Provide the ability to assign simple session numbers to scheduled sessions, typically in schedule order.', 0);
+
+INSERT INTO PatchLog (patchname) VALUES ('94ZED_session_number_module.sql');

--- a/client/src/page/compositePage.jsx
+++ b/client/src/page/compositePage.jsx
@@ -5,6 +5,7 @@ import AssignmentsPage from './assignment/assignmentsPage';
 import StaffVolunteerPage from './volunteer/staffVolunteerPage';
 import VolunteerSignUpPage from './volunteer/volunteerSignUpPage';
 import PrintRoomScheduleConfigPage from './tool/printRoomScheduleConfig';
+import SessionEnumerationConfigPage from './tool/sessionEnumerationConfig';
 
 /**
  * Implementing this as a sort-of pauper's version of a Router. We're starting with an
@@ -29,6 +30,8 @@ class CompositePage extends React.Component {
             return (<BrainstormPage />);
         } else if (url.pathname === '/assignParticipants.php') {
             return (<AssignmentsPage />);
+        } else if (url.pathname === '/assignSessionNumberConfig.php') {
+            return (<SessionEnumerationConfigPage />);
         } else if (url.pathname === '/printRoomScheduleConfig.php') {
             return (<PrintRoomScheduleConfigPage />);
         } else {

--- a/client/src/page/tool/sessionEnumerationConfig.jsx
+++ b/client/src/page/tool/sessionEnumerationConfig.jsx
@@ -1,0 +1,78 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+import LoadingButton from '../../common/loadingButton';
+import { redirectToLogin } from '../../common/redirectToLogin';
+import SimpleAlert from '../../common/simpleAlert';
+
+const SessionEnumerationConfigPage = () => {
+
+    let [buttonVariant, setButtonVariant] = useState("primary");
+    let [loading, setLoading] = useState(false);
+    let [message, setMessage] = useState(null);
+
+    useEffect(() => {
+        axios.get('/api/tool/session_enumerator.php')
+        .then(res => {
+            if (res.data.count > 0) {
+                setMessage({
+                    severity: "warning",
+                    text: "Sessions have already been assigned session numbers. Clicking 'Proceed' will overwrite those numbers."
+                });
+                setButtonVariant('danger');
+            }
+        })
+        .catch(error => {
+            if (error.response && error.response.status === 401) {
+                redirectToLogin();
+            } else {
+                setMessage({
+                    severity: "danger",
+                    text: "We've hit a bit of a technical snag trying to find out if session numbers have already been assigned."
+                });
+            }
+        });
+    }, []);
+
+    const assignNumbers = () => {
+        setLoading(true);
+        axios.post('/api/tool/session_enumerator.php')
+            .then(res => {
+                setLoading(false);
+                setMessage({
+                        severity: "success",
+                        text: "Ok. Session numbers have been assigned."
+                    });
+            })
+            .catch(error => {
+                console.log(error);
+                if (error.response && error.response.status === 401) {
+                    redirectToLogin();
+                } else {
+                    setLoading(false);
+                    setMessage({
+                            severity: "danger",
+                            text: "Sorry. We've had a bit of a technical problem. Try again?"
+                        });
+                }
+            });
+    }
+
+    return (<>
+        <SimpleAlert message={message} />
+        <div className="card mt-3">
+            <div className="card-header">
+                <h2>Session Enumeration</h2>
+            </div>
+            <div className="card-body">
+                <p>This tool assigns simple numbers to each of the sessions on the current schedule. The numbers should be assigned
+                based on start time, and room. The intention is that if you look at the grid view of the session, the numbers appear
+                to start at '1' and increment as you read left-to-right, top-to-bottom.</p>
+            </div>
+            <div className="card-footer text-right">
+                <LoadingButton variant={buttonVariant} loading={loading} onClick={() => assignNumbers() } enabled={true}>Proceed</LoadingButton>
+            </div>
+        </div>
+        </>);
+}
+
+export default SessionEnumerationConfigPage;

--- a/webpages/api/tool/session_enumerator.php
+++ b/webpages/api/tool/session_enumerator.php
@@ -1,0 +1,116 @@
+<?php
+
+require_once(__DIR__ . '/../../config/db_name.php');
+
+require_once(__DIR__ . '/../http_session_functions.php');
+require_once(__DIR__ . '/../authentication.php');
+require_once(__DIR__ . '/../db_support_functions.php');
+
+
+function count_session_numbers($db) {
+    $query = <<<EOD
+    SELECT count(sess.sessionid) as c
+      FROM Sessions sess
+      JOIN Schedule sch USING (sessionid)
+      JOIN Rooms r ON (sch.roomid = r.roomid)
+     WHERE sess.pubstatusid = 2
+       AND sess.pubsno IS NOT NULL
+       AND sess.pubsno != ''
+EOD;
+
+    $stmt = mysqli_prepare($db, $query);
+    $count = 0;
+    if (mysqli_stmt_execute($stmt)) {
+        $result = mysqli_stmt_get_result($stmt);
+        while ($row = mysqli_fetch_object($result)) {
+            $count = $row->c;
+        }
+        mysqli_stmt_close($stmt);
+        return $count;
+    } else {
+        throw new DatabaseSqlException("Query could not be executed: $query");
+    }
+}
+
+
+function enumerate_sessions($db) {
+    $query = <<<EOD
+    SELECT sess.sessionid
+      FROM Sessions sess
+      JOIN Schedule sch USING (sessionid)
+      JOIN Rooms r ON (sch.roomid = r.roomid)
+     WHERE sess.pubstatusid = 2
+     ORDER BY sch.starttime, r.display_order
+EOD;
+
+    $stmt = mysqli_prepare($db, $query);
+    $sessionIds = array();
+    if (mysqli_stmt_execute($stmt)) {
+        $result = mysqli_stmt_get_result($stmt);
+        while ($row = mysqli_fetch_object($result)) {
+            $sessionIds[] = $row->sessionid;
+        }
+        mysqli_stmt_close($stmt);
+    } else {
+        throw new DatabaseSqlException("Query could not be executed: $query");
+    }
+
+    $query = <<<EOD
+    UPDATE Sessions sess
+       SET pubsno = NULL;
+EOD;
+    $stmt = mysqli_prepare($db, $query);
+    if ($stmt->execute()) {
+        mysqli_stmt_close($stmt);
+    } else {
+        throw new DatabaseSqlException("The Update could not be processed: $query --> " . mysqli_error($db));
+    }
+
+$query = <<<EOD
+    UPDATE Sessions sess
+       SET pubsno = ?
+     WHERE sessionid = ?;
+EOD;
+    $stmt = mysqli_prepare($db, $query);
+    $enum = 1;
+    foreach ($sessionIds as $id) {
+        mysqli_stmt_bind_param($stmt, "ii", $enum, $id);
+        if ($stmt->execute()) {
+            $enum += 1;
+        } else {
+            throw new DatabaseSqlException("The Update could not be processed: $query --> " . mysqli_error($db));
+        }
+    }
+    mysqli_stmt_close($stmt);
+}
+
+start_session_if_necessary();
+$authentication = new Authentication();
+$db = connect_to_db();
+try {
+    if ($_SERVER['REQUEST_METHOD'] === 'POST' && $authentication->isProgrammingStaff()) {
+
+        $db->begin_transaction();
+        try {
+            enumerate_sessions($db);
+            $db->commit();
+            http_response_code(201);
+        } catch (Exception $e) {
+            $db->rollback();
+            throw $e;
+        }
+    } else if ($_SERVER['REQUEST_METHOD'] === 'GET' && $authentication->isProgrammingStaff()) {
+        $result = array("count" => count_session_numbers($db));
+        header('Content-type: application/json');
+        $json_string = json_encode($result);
+        echo $json_string;
+    } else if ($_SERVER['REQUEST_METHOD'] === 'POST' || $_SERVER['REQUEST_METHOD'] === 'GET') {
+        http_response_code(401); // not authenticated
+    } else {
+        http_response_code(405); // method not allowed
+    }
+} finally {
+    $db->close();
+}
+
+?>

--- a/webpages/assignSessionNumberConfig.php
+++ b/webpages/assignSessionNumberConfig.php
@@ -1,0 +1,4 @@
+<?php
+    require_once('reactPage.php');
+    reactPage("Assign Session Number Config", "Staff");
+?>

--- a/webpages/module/planz/session_number_module.php
+++ b/webpages/module/planz/session_number_module.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace PlanZ\Module;
+
+require_once(__DIR__ . "/../../tool_model.php");
+
+use Tool;
+
+class SessionNumberModule {
+
+    public static function getTools() {
+        $result = array();
+
+        $result[] = new Tool("Assign Session Numbers", "Assign simple session numbers for publications.", "assignSessionNumberConfig.php");
+        return $result;
+    }
+}
+
+?>


### PR DESCRIPTION
WisCon assigns simple session numbers to all sessions. Basically, once the schedule is "ready for print", we assign numbers sequentially starting at the first session of the con, and continuing to the last session of the con. So, for example, the first session of the con is number 1, the second is number 2, etc. It happens that we sometimes add things to the schedule after the ready-for-print day, and we manually assign numbers like "13b" for a session that falls between 13 and 14.

PlanZ has a field in the Sessions table -- the pubsno -- that was originally used for this purpose, but which has been largely deprecated. When we deployed a version of the code for WisCon, we made use of this field and had a custom tool to assign the session numbers. I'm now bringing that tool back into the codebase as an optional module.