### PR TITLE
Correct BS4 Less code to match CSS.

### DIFF
--- a/webpages/css/zambia_bs4.css
+++ b/webpages/css/zambia_bs4.css
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * File created by Peter Olszowka July 17, 2020
  * Copyright (c) 2020-2021 Peter Olszowka. All rights reserved. See copyright document for more details.
  */
@@ -265,38 +265,34 @@ footer {
 table.dataTable.table-sm thead th {
   padding: 0.3rem 18px 0.3rem 0.3rem;
 }
-table.dataTable.table-sm tbody th, table.dataTable.table-sm tbody td {
+table.dataTable.table-sm tbody th,
+table.dataTable.table-sm tbody td {
   padding: 0.3rem;
 }
 @media (pointer: fine) {
   .visible-on-hover button.btn {
-      display: none;
-      transition: 1s;
+    display: none;
+    transition: 1s;
   }
   .visible-on-hover:hover button.btn {
-      display: inline;
-      transition: 1s;
+    display: inline;
+    transition: 1s;
   }
 }
-
 table.table tr.highlight td {
   background-color: #f6ebc8;
 }
-
 table.table.table-striped tr.highlight:nth-child(odd) td {
   background-color: #d1c7a6;
 }
-
 .participant-avatar {
   width: 24rem;
   max-width: 100%;
   object-fit: cover;
 }
-
 .participant-avatar-sm {
   width: 5rem;
 }
-
 .participant-avatar-xs {
   width: 2rem;
 }

--- a/webpages/css/zambia_bs4.less
+++ b/webpages/css/zambia_bs4.less
@@ -40,19 +40,21 @@
 }
 
 .bs4 {
-    .nav-tabs {
-        border-bottom: 2px solid @gray;
-        
-        .nav-link {
-            background-color: @lightest-gray;
-            border: 2px solid @gray;
-            margin-left: 1px;
-            margin-right: 1px;
-        }
+    .config-table-editor {
+        .nav-tabs {
+            border-bottom: 2px solid @gray;
 
-        .nav-item.show .nav-link, .nav-link.active {
-            background-color: @white;
-            border-color: @near-black @near-black @gray;
+            .nav-link {
+                background-color: @lightest-gray;
+                border: 2px solid @gray;
+                margin-left: 1px;
+                margin-right: 1px;
+            }
+
+            .nav-item.show .nav-link, .nav-link.active {
+                background-color: @white;
+                border-color: @near-black @near-black @gray;
+            }
         }
     }
 }
@@ -109,7 +111,7 @@
 }
 
 @media (min-width: 768px) and (max-width: 991px) {
-    
+
 }
 
 @media (min-width: 992px) and (max-width: 1199px) {
@@ -164,10 +166,10 @@
 .tag-chk-label-wrapper {
     padding-bottom:0.3rem;
     padding-top:0.3rem;
-    
+
     &.disabled {
         background-color:@lightest-gray;
-        
+
         .tag-chk-label {
             font-style: italic;
         }
@@ -196,7 +198,7 @@
     padding-right: 1.5rem;
 }
 
-input[type='text'], input[type='password'] {
+input[type='text']:not(.form-control), input[type='password']:not(.form-control) {
     padding-left: 4px;
     padding-right: 4px;
 }
@@ -309,22 +311,63 @@ input[type='text'].disabled {
 /* End of Tabulator overrides */
 .session-status-definitions {
     max-width: 90rem;
-    
+
     dt {
         margin-left: 2rem;
     }
-    
+
     dd {
         margin-left: 4rem;
     }
 }
 
-table.dataTable.table-sm { 
+footer {
+    padding-top: 1rem;
+}
+
+table.dataTable.table-sm {
     thead th {
         padding: 0.3rem 18px 0.3rem 0.3rem;
     }
-    tbody th, 
+    tbody th,
     tbody td {
         padding: 0.3rem;
     }
+}
+
+@media (pointer: fine) {
+    .visible-on-hover button.btn {
+        display: none;
+        transition: 1s;
+    }
+    .visible-on-hover:hover button.btn {
+        display: inline;
+        transition: 1s;
+    }
+}
+
+table.table {
+    tr.highlight {
+        td {
+            background-color: #f6ebc8;
+        }
+    }
+}
+
+table.table.table-striped tr.highlight:nth-child(odd) td {
+    background-color: #d1c7a6;
+}
+
+.participant-avatar {
+    width: 24rem;
+    max-width: 100%;
+    object-fit: cover;
+}
+
+.participant-avatar-sm {
+    width: 5rem;
+}
+
+.participant-avatar-xs {
+    width: 2rem;
 }


### PR DESCRIPTION
This change is to fix `zambia_bs4.less` to match the CSS in `zambia_bs4.css`.
It would appear that styles have been changed or added in the CSS file without adding to the Less file. I have updated the Less file so that it should generate the CSS currently in use. Some of the formatting has changed slightly, as some of the added CSS was incorrectly indented, but all styles should appear unchanged.
I haven't checked any other CSS/Less files, so it would be worth reviewing them too.