### PR TITLE
Fix paths and add max email limit to processEmailQueue

### DIFF
--- a/scripts/processEmailQueue.php
+++ b/scripts/processEmailQueue.php
@@ -4,9 +4,10 @@
 //Need to add some code to prevent it from being accessed any other way, but leave it exposed for now for testing.
 
 error_reporting(E_ERROR);
-require_once('webpages/db_functions.php'); //reset connection to db and check if logged in
-require_once('webpages/email_functions.php');
-require_once('webpages/external/swiftmailer-5.4.8/lib/swift_required.php');
+require_once __DIR__ . '/../webpages/db_functions.php';
+require_once __DIR__ . '/../webpages/email_functions.php';
+require_once __DIR__ .
+    '/../webpages/external/swiftmailer-5.4.8/lib/swift_required.php';
 
 if (prepare_db_and_more() === false) {
     echo "Unable to connect to database.\nNo further execution possible.\n";
@@ -19,9 +20,15 @@ $mailer = get_swift_mailer();
 //$logger = new Swift_Plugins_Loggers_EchoLogger();
 //$mailer->registerPlugin(new Swift_Plugins_LoggerPlugin($logger));
 
-$sql = "SELECT emailqueueid, emailto, emailfrom, emailcc, emailsubject, body, status, emailtimestamp FROM EmailQueue;";
+// If SMTP_MAX_MESSAGES set, add LIMIT clause to SQL.
+if (defined('SMTP_MAX_MESSAGES') && SMTP_MAX_MESSAGES != '0' && is_numeric(SMTP_MAX_MESSAGES)) {
+    $limit = "LIMIT " . SMTP_MAX_MESSAGES;
+} else {
+    $limit = '';
+}
+$sql = "SELECT emailqueueid, emailto, emailfrom, emailcc, emailsubject, body, status, emailtimestamp FROM EmailQueue $limit;";
 $result = mysqli_query_exit_on_error($sql);
-while($row = mysqli_fetch_assoc($result)) {
+while ($row = mysqli_fetch_assoc($result)) {
     $action = "";
     $queueid = $row["emailqueueid"];
     echo "checking: $queueid\n";
@@ -37,7 +44,7 @@ while($row = mysqli_fetch_assoc($result)) {
         if ($row["emailcc"] != "") {
             $message->addBcc($emailcc);
         }
-        $message->setBody($row["body"],'text/plain');
+        $message->setBody($row["body"], 'text/plain');
         $emailto = $row["emailto"];
         try {
             $message->addTo($emailto);

--- a/webpages/config/db_name_sample.php
+++ b/webpages/config/db_name_sample.php
@@ -32,7 +32,8 @@ define("DISPLAY_24_HOUR_TIME", FALSE); // TRUE: times in 24 hour clock. FALSE: t
 define("DURATION_IN_MINUTES", FALSE); // TRUE: in mmm; FALSE: in hh:mm
         // affects session edit/create page only, not reports
 define("DEFAULT_DURATION", "1:15"); // must correspond to DURATION_IN_MINUTES
-define("SMTP_QUEUEONLY", FALSE); // TRUE = add to DB queue, schedule processEmailQueue.php as a cron job do the send; FALSE send immediately, add to queue only on transport failure
+define("SMTP_QUEUEONLY", FALSE); // TRUE = add to DB queue, schedule /scripts/processEmailQueue.php as a cron job do the send; FALSE send immediately, add to queue only on transport failure
+define("SMTP_MAX_MESSAGES", "100"); // Maximum number of messages to send per cron run. Set to 0 for no limit.
 define("PREF_TTL_SESNS_LMT", 10); // Input data verification limit for preferred total number of sessions
 define("PREF_DLY_SESNS_LMT", 5); // Input data verification limit for preferred daily limit of sessions
 define("AVAILABILITY_ROWS", 8); // Number of rows of availability records to render


### PR DESCRIPTION
`processEmailQueue.php` was moved into scripts, but paths were not updated, so it was looking for webpages/ under scripts/.

Updated to use `__DIR__` and access paths relative to there.

The script also seems to have been designed to avoid webpage timeouts, but not for email server sending limits.

If the email server restricts the number of mails sent, in a time period, it may get rejection errors.

I have added a new setting, `SMTP_MAX_MESSAGES` that contains the maximum number of messages to send per run. It will limit the query to that number of messages. If set to zero, all messages will be sent.