### PR TITLE
Fix paths in konOpasCron.php.

### DIFF
--- a/scripts/konOpasCron.php
+++ b/scripts/konOpasCron.php
@@ -4,27 +4,26 @@
 //Need to add some code to prevent it from being accessed any other way, but leave it exposed for now for testing.
 
 error_reporting(E_ERROR);
-require_once('webpages/konOpas_func.php');
+require_once __DIR__ . '/../webpages/konOpas_func.php';
 
 $results = retrieveKonOpasData();
 if ($results["message_error"]) {
-        error_log("konOpas.php: ".$results["message_error"]);
+    error_log("konOpas.php: ".$results["message_error"]);
+    exit(1);
+} else if ($results["json"]) {
+    echo "Hello\n";
+    $resultsFile = fopen(__DIR__ . "/../webpages/konOpasData.jsonp", "wb");
+    if ($resultsFile === false) {
+        error_log("konOpas.php: Can't open webpages/konOpasData.jsonp for writing.");
         exit(1);
-        }
-    else if ($results["json"]) {
-        $resultsFile = fopen("webpages/konOpasData.jsonp","wb");
-        if ($resultsFile === FALSE) {
-            error_log("konOpas.php: Can't open webpages/konOpasData.jsonp for writing.");
-            exit(1);
-            }
-        if (fwrite($resultsFile, $results["json"]) === FALSE) {
-            error_log("konOpas.php: Error writing to webpages/konOpasData.jsonp.");
-            exit(1);
-            }
-        exit();
-        }
-    else {
-        error_log("konOpas.php: retrieveKonOpasData() did not return expected result or error indicator.");
+    }
+    if (fwrite($resultsFile, $results["json"]) === false) {
+        error_log("konOpas.php: Error writing to webpages/konOpasData.jsonp.");
         exit(1);
-        }
+    }
+    exit();
+} else {
+    error_log("konOpas.php: retrieveKonOpasData() did not return expected result or error indicator.");
+    exit(1);
+}
 ?>


### PR DESCRIPTION
`konOpasCron.php` was moved to scripts directory, but paths to webpages were not updated. Updated paths and tidied up some indentation.

This is a minimal update to make it work, however the KonOpas/Conclár output on the admin menu does quite a bit more, so a future change might be to implement that functionality.

There might also be a change to tie into the module system and implement a generic cron task manager in that.