### PR TITLE
include is not a function!

### DIFF
--- a/webpages/HeaderImage.php
+++ b/webpages/HeaderImage.php
@@ -2,8 +2,8 @@
 //	Created by BC Holmes
 //  This file providees a consistent URL for requesting the PlanZ configurable header image
 
-if (!include ('./config/db_name.php')) {
-    include ('./config/db_name.php');
+if (file_exists(__DIR__ . '/config/db_name.php')) {
+    include __DIR__ . '/config/db_name.php';
 }
 
 if (defined('CON_HEADER_IMG') && CON_HEADER_IMG !== "") {

--- a/webpages/api/admin/modules.php
+++ b/webpages/api/admin/modules.php
@@ -5,8 +5,8 @@ namespace PlanZ;
 // Copyright (c) 2022 BC Holmes. All rights reserved. See copyright document for more details.
 // This function provides basic management for modules: allowing admins to enable modules.
 
-if (!include ('../../config/db_name.php')) {
-    include ('../../config/db_name.php');
+if (file_exists(__DIR__ . '/../../config/db_name.php')) {
+    include __DIR__ . '/../../config/db_name.php';
 }
 require_once('../../db_exceptions.php');
 require_once('../../login_functions.php');

--- a/webpages/api/assignment/assign_moderator.php
+++ b/webpages/api/assignment/assign_moderator.php
@@ -2,8 +2,8 @@
 // Copyright (c) 2022 BC Holmes. All rights reserved. See copyright document for more details.
 // This function serves as a REST API to access session history information.
 
-if (!include ('../../config/db_name.php')) {
-    include ('../../config/db_name.php');
+if (file_exists(__DIR__ . '/../../config/db_name.php')) {
+    include __DIR__ . '/../../config/db_name.php';
 }
 
 require_once('../http_session_functions.php');

--- a/webpages/api/assignment/assign_note.php
+++ b/webpages/api/assignment/assign_note.php
@@ -2,8 +2,8 @@
 // Copyright (c) 2023 BC Holmes. All rights reserved. See copyright document for more details.
 // This function serves as a REST API to access session history information.
 
-if (!include ('../../config/db_name.php')) {
-    include ('../../config/db_name.php');
+if (file_exists(__DIR__ . '/../../config/db_name.php')) {
+    include __DIR__ . '/../../config/db_name.php';
 }
 
 require_once('../http_session_functions.php');

--- a/webpages/api/assignment/assignments.php
+++ b/webpages/api/assignment/assignments.php
@@ -2,8 +2,8 @@
 // Copyright (c) 2022 BC Holmes. All rights reserved. See copyright document for more details.
 // This function serves as a REST API to access session history information.
 
-if (!include ('../../config/db_name.php')) {
-    include ('../../config/db_name.php');
+if (file_exists(__DIR__ . '/../../config/db_name.php')) {
+    include __DIR__ . '/../../config/db_name.php';
 }
 
 require_once('../http_session_functions.php');

--- a/webpages/api/assignment/create_assignment.php
+++ b/webpages/api/assignment/create_assignment.php
@@ -2,8 +2,8 @@
 // Copyright (c) 2022 BC Holmes. All rights reserved. See copyright document for more details.
 // This function serves as a REST API to access session history information.
 
-if (!include ('../../config/db_name.php')) {
-    include ('../../config/db_name.php');
+if (file_exists(__DIR__ . '/../../config/db_name.php')) {
+    include __DIR__ . '/../../config/db_name.php';
 }
 
 require_once('../http_session_functions.php');

--- a/webpages/api/assignment/find_potential_candidates.php
+++ b/webpages/api/assignment/find_potential_candidates.php
@@ -2,8 +2,8 @@
 // Copyright (c) 2022 BC Holmes. All rights reserved. See copyright document for more details.
 // This function serves as a REST API to look up potential candidates
 
-if (!include ('../../config/db_name.php')) {
-    include ('../../config/db_name.php');
+if (file_exists(__DIR__ . '/../../config/db_name.php')) {
+    include __DIR__ . '/../../config/db_name.php';
 }
 
 require_once('../http_session_functions.php');

--- a/webpages/api/assignment/remove_assignment.php
+++ b/webpages/api/assignment/remove_assignment.php
@@ -2,8 +2,8 @@
 // Copyright (c) 2022 BC Holmes. All rights reserved. See copyright document for more details.
 // This function serves as a REST API to access session history information.
 
-if (!include ('../../config/db_name.php')) {
-    include ('../../config/db_name.php');
+if (file_exists(__DIR__ . '/../../config/db_name.php')) {
+    include __DIR__ . '/../../config/db_name.php';
 }
 
 require_once('../http_session_functions.php');

--- a/webpages/api/confirm_session_assignment.php
+++ b/webpages/api/confirm_session_assignment.php
@@ -1,8 +1,8 @@
 <?php
 // Created by BC Holmes on 2022-03-16.
 
-if (!include ('../config/db_name.php')) {
-    include ('../config/db_name.php');
+if (file_exists(__DIR__ . '/../config/db_name.php')) {
+    include __DIR__ . '/../config/db_name.php';
 }
 
 require_once('../db_exceptions.php');

--- a/webpages/api/create_new_account.php
+++ b/webpages/api/create_new_account.php
@@ -2,8 +2,8 @@
 // Copyright (c) 2021 BC Holmes. All rights reserved. See copyright document for more details.
 // This function finds the panel list that we want to solicit participant feedback for.
 
-if (!include ('../config/db_name.php')) {
-    include ('../config/db_name.php');
+if (file_exists(__DIR__ . '/../config/db_name.php')) {
+    include __DIR__ . '/../config/db_name.php';
 }
 require_once('../external/swiftmailer-5.4.8/lib/swift_required.php');
 require_once('../db_exceptions.php');
@@ -19,7 +19,7 @@ function send_email_to_support($email, $badgeName, $badgeid) {
     <p>Hi $supportName</p>
     <p>
         A user has created a new account in the programming system. We just thought you should
-        know that because it could be legit, or it could be nasty hackers from Russia. 
+        know that because it could be legit, or it could be nasty hackers from Russia.
     </p>
     <p>
         <b>Name: </b> $badgeName<br />
@@ -65,7 +65,7 @@ EOD;
         }
         $result->free_result();
         $stmt->close();
-        
+
         return $email;
     } else {
         throw new DatabaseSqlException("The query could not be processed");
@@ -120,7 +120,7 @@ function split_first_and_last_names($name) {
             if ($i > 0) {
                 $first .= ' ';
             }
-            $first .= $words[$i]; 
+            $first .= $words[$i];
         }
         return array("first_name" => $first,
             "last_name" => $last);
@@ -149,7 +149,7 @@ function create_new_participant($db, $badgeid, $pubsname, $email_address, $passw
     $query = <<<EOD
     INSERT
         INTO `Participants` (badgeid, pubsname, password)
- VALUES 
+ VALUES
         (?, ?, ?);
 EOD;
 
@@ -167,7 +167,7 @@ EOD;
     $query = <<<EOD
     INSERT
         INTO `CongoDump` (badgeid, badgename, `email`, firstname, lastname)
-    VALUES 
+    VALUES
         (?, ?, ?, ?, ?);
 EOD;
 
@@ -180,7 +180,7 @@ EOD;
     }
 
     $query = <<<EOD
-    INSERT INTO `UserHasPermissionRole` 
+    INSERT INTO `UserHasPermissionRole`
         (badgeid, permroleid)
     SELECT ?, permroleid
       FROM PermissionRoles
@@ -203,7 +203,7 @@ try {
         $json_string = file_get_contents('php://input');
         $json = json_decode($json_string, true);
 
-        if (array_key_exists('control', $json) && array_key_exists('controliv', $json) 
+        if (array_key_exists('control', $json) && array_key_exists('controliv', $json)
             && array_key_exists('badgeName', $json) && array_key_exists('password', $json)) {
 
             $control = interpretControlString($json['control'], $json['controliv']);

--- a/webpages/api/fetch_participant.php
+++ b/webpages/api/fetch_participant.php
@@ -2,8 +2,8 @@
 // Copyright (c) 2022 BC Holmes. All rights reserved. See copyright document for more details.
 // This function serves as a REST API to access session history information.
 
-if (!include ('../config/db_name.php')) {
-    include ('../config/db_name.php');
+if (file_exists(__DIR__ . '/../config/db_name.php')) {
+    include __DIR__ . '/../config/db_name.php';
 }
 require_once('./http_session_functions.php');
 require_once('../db_exceptions.php');
@@ -64,7 +64,7 @@ EOD;
         $rs = mysqli_stmt_get_result($stmt);
         while ($row = mysqli_fetch_object($rs)) {
             $name = PersonName::from($row);
-            $result = array( 
+            $result = array(
                 "badgeId" => $row->badgeid,
                 "name" => $name->asArray(),
                 "interested" => $row->interested == 1 ? true : false,

--- a/webpages/api/login.php
+++ b/webpages/api/login.php
@@ -2,8 +2,8 @@
 // Copyright (c) 2021 BC Holmes. All rights reserved. See copyright document for more details.
 // This function provides support for mobile apps such as WisSched and FogGuide
 
-if (!include ('../config/db_name.php')) {
-    include ('../config/db_name.php');
+if (file_exists(__DIR__ . '/../config/db_name.php')) {
+    include __DIR__ . '/../config/db_name.php';
 }
 
 require_once('../db_exceptions.php');

--- a/webpages/api/scheduler/auto_scheduler.php
+++ b/webpages/api/scheduler/auto_scheduler.php
@@ -1,7 +1,7 @@
 <?php
 
-if (!include ('../../config/db_name.php')) {
-    include ('../../config/db_name.php');
+if (file_exists(__DIR__ . '/../../config/db_name.php')) {
+    include __DIR__ . '/../../config/db_name.php';
 }
 
 require_once('../../db_exceptions.php');

--- a/webpages/api/session_feedback_list.php
+++ b/webpages/api/session_feedback_list.php
@@ -2,8 +2,8 @@
 // Copyright (c) 2021 BC Holmes. All rights reserved. See copyright document for more details.
 // This function finds the panel list that we want to solicit participant feedback for.
 
-if (!include ('../config/db_name.php')) {
-    include ('../config/db_name.php');
+if (file_exists(__DIR__ . '/../config/db_name.php')) {
+    include __DIR__ . '/../config/db_name.php';
 }
 require_once('../db_exceptions.php');
 require_once('./db_support_functions.php');
@@ -53,7 +53,7 @@ function find_session_for_feedback($db, $badgeid, $term) {
        $clause
      ORDER BY t.display_order, s.sessionid;
 EOD;
-   
+
     $stmt = mysqli_prepare($db, $query);
     mysqli_stmt_bind_param($stmt, "s", $badgeid);
     if (mysqli_stmt_execute($stmt)) {

--- a/webpages/api/session_feedback_update.php
+++ b/webpages/api/session_feedback_update.php
@@ -2,8 +2,8 @@
 // Copyright (c) 2021 BC Holmes. All rights reserved. See copyright document for more details.
 // This function finds the panel list that we want to solicit participant feedback for.
 
-if (!include ('../config/db_name.php')) {
-    include ('../config/db_name.php');
+if (file_exists(__DIR__ . '/../config/db_name.php')) {
+    include __DIR__ . '/../config/db_name.php';
 }
 require_once('../db_exceptions.php');
 require_once('./db_support_functions.php');
@@ -16,7 +16,7 @@ function choose_query_based_on_field($name) {
         $query = <<<EOD
         INSERT  INTO ParticipantSessionInterest
                 (badgeid, sessionid, rank)
-        VALUES (?, ?, ?) 
+        VALUES (?, ?, ?)
         ON DUPLICATE KEY UPDATE rank = ?;
 EOD;
         return $query;
@@ -24,7 +24,7 @@ EOD;
         $query = <<<EOD
         INSERT  INTO ParticipantSessionInterest
                 (badgeid, sessionid, willmoderate)
-        VALUES (?, ?, ?) 
+        VALUES (?, ?, ?)
         ON DUPLICATE KEY UPDATE willmoderate = ?;
 EOD;
         return $query;
@@ -32,7 +32,7 @@ EOD;
         $query = <<<EOD
         INSERT  INTO ParticipantSessionInterest
                 (badgeid, sessionid, attend)
-        VALUES (?, ?, ?) 
+        VALUES (?, ?, ?)
         ON DUPLICATE KEY UPDATE attend = ?;
 EOD;
         return $query;
@@ -40,7 +40,7 @@ EOD;
         $query = <<<EOD
         INSERT  INTO ParticipantSessionInterest
                 (badgeid, sessionid, attend_type)
-        VALUES (?, ?, ?) 
+        VALUES (?, ?, ?)
         ON DUPLICATE KEY UPDATE attend_type = ?;
 EOD;
         return $query;
@@ -48,7 +48,7 @@ EOD;
         $query = <<<EOD
         INSERT  INTO ParticipantSessionInterest
                 (badgeid, sessionid, comments)
-        VALUES (?, ?, ?) 
+        VALUES (?, ?, ?)
         ON DUPLICATE KEY UPDATE comments = ?;
 EOD;
         return $query;

--- a/webpages/api/view_session_history.php
+++ b/webpages/api/view_session_history.php
@@ -2,8 +2,8 @@
 // Copyright (c) 2022 BC Holmes. All rights reserved. See copyright document for more details.
 // This function serves as a REST API to access session history information.
 
-if (!include ('../config/db_name.php')) {
-    include ('../config/db_name.php');
+if (file_exists(__DIR__ . '/../config/db_name.php')) {
+    include __DIR__ . '/../config/db_name.php';
 }
 require_once('./http_session_functions.php');
 require_once('../db_exceptions.php');

--- a/webpages/api/view_session_participants.php
+++ b/webpages/api/view_session_participants.php
@@ -2,8 +2,8 @@
 // Copyright (c) 2022 BC Holmes. All rights reserved. See copyright document for more details.
 // This function serves as a REST API to access session history information.
 
-if (!include ('../config/db_name.php')) {
-    include ('../config/db_name.php');
+if (file_exists(__DIR__ . '/../config/db_name.php')) {
+    include __DIR__ . '/../config/db_name.php';
 }
 require_once('./http_session_functions.php');
 require_once('../db_exceptions.php');
@@ -41,7 +41,7 @@ EOD;
             $name->lastName = $row->lastname;
             $name->badgeName = $row->badgename;
             $name->pubsName = $row->pubsname;
-            $assignments[] = [ 
+            $assignments[] = [
                 "badgeid" => $row->badgeid,
                 "moderator" => $row->moderator ? true : false,
                 "name" => $name->getBadgeName()

--- a/webpages/api/volunteer/create_volunteer_job.php
+++ b/webpages/api/volunteer/create_volunteer_job.php
@@ -2,8 +2,8 @@
 // Copyright (c) 2022 BC Holmes. All rights reserved. See copyright document for more details.
 // This function serves as a REST API to access session history information.
 
-if (!include ('../../config/db_name.php')) {
-    include ('../../config/db_name.php');
+if (file_exists(__DIR__ . '/../../config/db_name.php')) {
+    include __DIR__ . '/../../config/db_name.php';
 }
 require_once('../http_session_functions.php');
 require_once('../../db_exceptions.php');
@@ -30,7 +30,7 @@ try {
         if (is_input_data_valid($json)) {
             $job = VolunteerJob::fromJson($json);
             VolunteerJob::persist($db, $job);
-    
+
             http_response_code(201);
         } else {
             http_response_code(400);

--- a/webpages/api/volunteer/create_volunteer_shift.php
+++ b/webpages/api/volunteer/create_volunteer_shift.php
@@ -2,8 +2,8 @@
 // Copyright (c) 2022 BC Holmes. All rights reserved. See copyright document for more details.
 // This function serves as a REST API to create a volunteer shift
 
-if (!include ('../../config/db_name.php')) {
-    include ('../../config/db_name.php');
+if (file_exists(__DIR__ . '/../../config/db_name.php')) {
+    include __DIR__ . '/../../config/db_name.php';
 }
 require_once('../con_info.php');
 require_once('../http_session_functions.php');

--- a/webpages/api/volunteer/get_volunteer_jobs.php
+++ b/webpages/api/volunteer/get_volunteer_jobs.php
@@ -2,8 +2,8 @@
 // Copyright (c) 2022 BC Holmes. All rights reserved. See copyright document for more details.
 // This function serves as a REST API to access session history information.
 
-if (!include ('../../config/db_name.php')) {
-    include ('../../config/db_name.php');
+if (file_exists(__DIR__ . '/../../config/db_name.php')) {
+    include __DIR__ . '/../../config/db_name.php';
 }
 require_once('../http_session_functions.php');
 require_once('../../db_exceptions.php');

--- a/webpages/api/volunteer/get_volunteer_shifts.php
+++ b/webpages/api/volunteer/get_volunteer_shifts.php
@@ -2,8 +2,8 @@
 // Copyright (c) 2022 BC Holmes. All rights reserved. See copyright document for more details.
 // This function serves as a REST API to access volunteer shifts
 
-if (!include ('../../config/db_name.php')) {
-    include ('../../config/db_name.php');
+if (file_exists(__DIR__ . '/../../config/db_name.php')) {
+    include __DIR__ . '/../../config/db_name.php';
 }
 require_once('../con_info.php');
 require_once('../http_session_functions.php');

--- a/webpages/api/volunteer/my_shift_assignments.php
+++ b/webpages/api/volunteer/my_shift_assignments.php
@@ -2,8 +2,8 @@
 // Copyright (c) 2022 BC Holmes. All rights reserved. See copyright document for more details.
 // This function serves as a REST API to access volunteer shift assignments (getting, creating and deleting)
 
-if (!include ('../../config/db_name.php')) {
-    include ('../../config/db_name.php');
+if (file_exists(__DIR__ . '/../../config/db_name.php')) {
+    include __DIR__ . '/../../config/db_name.php';
 }
 require_once('../con_info.php');
 require_once('../http_session_functions.php');

--- a/webpages/staffReportsInCategory.php
+++ b/webpages/staffReportsInCategory.php
@@ -17,7 +17,9 @@ $prevErrorLevel = error_reporting();
 $tempErrorLevel = $prevErrorLevel & ~ E_WARNING;
 error_reporting($tempErrorLevel);
 $includeFile = REPORT_INCLUDE_DIRECTORY . 'staffReportsInCategoryInclude.php';
-if (!include $includeFile) {
+if (file_exists($includeFile)) {
+    include $includeFile;
+} else {
     $message_error = "Report menus not built.  File $includeFile not found.";
     RenderError($message_error);
     exit();
@@ -37,7 +39,7 @@ staff_header($title, true);
     <div class="row mt-2">
         <div class=" col-md-9">
             <div class="list-group">
-<?php 
+<?php
 $reportList = array();
 foreach ($reportItem as $reportFileName => $item) {
     if ($reportcategoryid === "" || in_array($reportcategoryid, $item['categories'])) {
@@ -62,6 +64,6 @@ foreach ($reportList as $r => $record) {
         </div>
     </div>
 </div>
-<?php 
+<?php
 staff_footer();
 ?>


### PR DESCRIPTION
There are a lot of places that use the pattern:

```
if (!include("___")) {
    include ("___");
}
```

The `include` statement does not work as a function, so while this doesn't seem to cause any errors, it is not a valid PHP pattern.

This change replaces the condition with `file_exists`, which makes more sense. I've also added `__DIR__` to the paths. It would have been tempting to also add this to the other requires/includes in these files, but I decided it better to only include the fix for this pattern in this change since it's changing a lot of files at once.