### PR TITLE
Add option to hide participant comments on My Schedule

### DIFF
--- a/webpages/MySchedule.php
+++ b/webpages/MySchedule.php
@@ -46,7 +46,7 @@ SELECT
 EOD;
 $queryArr["participants"] = <<<EOD
 SELECT
-        POS.participantonsessionid, P.badgeid, POS.sessionid, CD.badgename, P.pubsname, 
+        POS.participantonsessionid, P.badgeid, POS.sessionid, CD.badgename, P.pubsname,
         IF (P.share_email=1, CD.email, NULL) AS email,
         POS.moderator, PSI.comments, POS.confirmed, POS.notes
     FROM
@@ -117,14 +117,21 @@ if (defined('CONFIRM_SESSION_ASSIGNMENT') && CONFIRM_SESSION_ASSIGNMENT === TRUE
     $allowConfirmation = 'true';
 ?>
     <div class="alert alert-primary">Please take a moment to confirm your panel assignments.</div>
-<?php 
+<?php
 }
 ?>
 <div class="card">
     <div class="card-body">
 <?php
 
-RenderXSLT('my_schedule.xsl', array( "badgeid" => $badgeid, "allowConfirmation" => $allowConfirmation ), $resultXML);
+RenderXSLT(
+    'my_schedule.xsl', [
+        "badgeid" => $badgeid,
+        "allowConfirmation" => $allowConfirmation,
+        "showComments" => MY_SCHEDULE_SHOW_COMMENTS ? 'true' : 'false',
+    ],
+    $resultXML
+);
 ?>
     </div>
 </div>

--- a/webpages/config/db_name_sample.php
+++ b/webpages/config/db_name_sample.php
@@ -96,6 +96,9 @@ define('LABEL_SEXUAL_ORIENTATION', "Sexual Orientation:"); // Label for sexual o
 define("USE_PRONOUNS", TRUE); // Let participants specify their pronouns on Personal Details page.
 define("LABEL_PRONOUNS_ARE", "My pronouns are:"); // Label for pronouns drop-down.
 define("LABEL_PRONOUNS_OTHER", "If you selected \"other\" for your pronouns, provide your pronouns here:"); // Label for "other" pronouns.
+
+define('MY_SCHEDULE_SHOW_COMMENTS', TRUE); // Should participant comments be shown on My Schedule?
+
 define("REG_PART_PREFIX", ""); // only needed for USE_REG_SYSTEM = FALSE; prefix portion of userid/badgeid before counter; can be empty string for no prefix
 define("REG_PART_DIGITS", 4); // only needed for USE_REG_SYSTEM = FALSE; number of digits to pad counter; if number has fewer than specified digits, will left pad with zeros
 define("HTML_BIO", TRUE); // Allow editing BIO as HTML and saving it both as plain text and HTML

--- a/webpages/xsl/my_schedule.xsl
+++ b/webpages/xsl/my_schedule.xsl
@@ -7,6 +7,7 @@
 <xsl:stylesheet version="1.1" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
     <xsl:param name="badgeid" select="''"/>
     <xsl:param name="allowConfirmation" select="'true'"/>
+	<xsl:param name="showComments" select="'true'" />
 	<xsl:output encoding="UTF-8" indent="yes" method="html" />
 	<xsl:template match="/">
 		<xsl:choose>
@@ -18,7 +19,7 @@
 			</xsl:otherwise>
 		</xsl:choose>
 	</xsl:template>
-	
+
 	<xsl:template match="doc/query[@queryName='sessions']/row">
 		<div class="mb-5">
 			<h5 class="mb-0"><xsl:value-of select="@title" disable-output-escaping="yes"/></h5>
@@ -143,19 +144,21 @@
 					</xsl:otherwise>
 				</xsl:choose>
 			</div>
-			<div>
-				<xsl:attribute name="class">
-					<xsl:choose>
-						<xsl:when test="$allowConfirmation = 'true'">
-							<xsl:text>col-lg-3</xsl:text>
-						</xsl:when>
-						<xsl:otherwise>
-							<xsl:text>col-lg-6</xsl:text>
-						</xsl:otherwise>
-					</xsl:choose>
-				</xsl:attribute>
-				<xsl:value-of select="@comments" />
-			</div>
+			<xsl:if test="$showComments = 'true'">
+				<div>
+					<xsl:attribute name="class">
+						<xsl:choose>
+							<xsl:when test="$allowConfirmation = 'true'">
+								<xsl:text>col-lg-3</xsl:text>
+							</xsl:when>
+							<xsl:otherwise>
+								<xsl:text>col-lg-6</xsl:text>
+							</xsl:otherwise>
+						</xsl:choose>
+					</xsl:attribute>
+					<xsl:value-of select="@comments" />
+				</div>
+			</xsl:if>
 		</div>
 		<xsl:if test="@badgeid = $badgeid and $allowConfirmation = 'true'">
 			<div class="row mb-2 align-items-baseline">


### PR DESCRIPTION
When users express interest in sessions, it's not obvious that their comments will be visible to the other participants, and some participants can be quite frank in what they write there.

This change adds a "MY_SCHEDULE_SHOW_COMMENTS" setting to enable the administrator to decide whether comments will be shown on the MySchedule page or not.

Note that you will need to add this setting to your db_name.php. This can be done automatically by opening the configuration editor and pressing Save.