### PR TITLE
Second Description Option, even when Bilingual is not in use

### DIFF
--- a/webpages/RenderEditCreateSession.php
+++ b/webpages/RenderEditCreateSession.php
@@ -176,7 +176,7 @@ function RenderEditCreateSession ($action, $session, $message1, $message2) {
                 <textarea class="form-control" rows="4" cols="70" name="progguiddesc" id="progguiddesc"
                     readonly="readonly"><?php echo htmlspecialchars($session["progguiddesc"],ENT_NOQUOTES);?></textarea>
 <?php
-        if (BILINGUAL === TRUE) {
+        if (BILINGUAL === TRUE || SECOND_SESSION_SECTION === TRUE) {
 ?>
                 <label class="control-label vert-sep vert-sep-above" for="pocketprogtext">
                     <?php echo SECOND_DESCRIPTION_CAPTION;?>:
@@ -204,12 +204,12 @@ function RenderEditCreateSession ($action, $session, $message1, $message2) {
                     rows="5" cols="70" name="progguiddesc"><?php echo htmlspecialchars($session["progguiddesc"],ENT_NOQUOTES);?></textarea>
             </div>
 <?php
-        if (BILINGUAL === TRUE) {
+        if (BILINGUAL === TRUE || SECOND_SESSION_SECTION === TRUE) {
 ?>
             <div class="form-group col-md-6">
                 <label for="pocketprogtext"><?php echo SECOND_DESCRIPTION_CAPTION;?>: </label>
                 <textarea class="form-control"
-                    rows="4" cols="70" name="pocketprogtext"><?php echo htmlspecialchars($session["pocketprogtext"],ENT_NOQUOTES);?></textarea>
+                    rows="5" cols="70" name="pocketprogtext"><?php echo htmlspecialchars($session["pocketprogtext"],ENT_NOQUOTES);?></textarea>
             </div>
 <?php
         } else {

--- a/webpages/config/db_name_sample.php
+++ b/webpages/config/db_name_sample.php
@@ -49,6 +49,7 @@ define("SECOND_LANG", "FRENCH");
 define("SECOND_TITLE_CAPTION", "Titre en fran&ccedil;ais");
 define("SECOND_DESCRIPTION_CAPTION", "Description en fran&ccedil;ais");
 define("SECOND_BIOGRAPHY_CAPTION", "Biographie en fran&ccedil;ais");
+define("SECOND_SESSION_SECTION", FALSE); // Show and allow editing of the second session description (assuming bilingual is off)
 define("SHOW_BRAINSTORM_LOGIN_HINT", FALSE);
 define("USER_ID_PROMPT", "User ID"); // What to label User ID / Badge ID / Email
 define("LOGIN_PAGE_USER_ID_PROMPT", ""); // What to label User ID / Badge ID specifically on the login page (blank defaults to the value of USER_ID_PROMPT)


### PR DESCRIPTION
The Sessions table has two "description" fields:

- progguiddesc
- pocketprogtext

Although not obvious, the second field is currently used when the BILINGUAL option is TRUE in the db_name file (so, for example, a session at an English and Spanish con would use one field for English and the second field for Spanish. 

At WisCon, however, we use that second field in Academic programming. When we receive proposals for Academic presentations at WisCon, we accept both a description for the programming guide, and a 500 word abstract of the paper being presented. Academic programming personnel use the abstract when they're planning and/or scheduling Academic presentations.

This PR gives us a config option to show the pocketprogtext field even if the BILINGUAL property is set to FALSE.