### PR TITLE
Remove the page name from the nav bar

### DIFF
--- a/webpages/ParticipantHeader.php
+++ b/webpages/ParticipantHeader.php
@@ -62,7 +62,6 @@ function participant_header($title, $noUserRequired = false, $loginPageStatus = 
                         <span class="icon-bar"></span>
                         <span class="icon-bar"></span>
                     </a>
-                    <a class="brand" href="<?php if (isset($_SERVER['PATH_INFO'])) echo $_SERVER['PATH_INFO'] ?>"><?php echo $title ?></a>
                     <div class="nav-collapse">
                         <ul class="nav">
                             <li><a href="welcome.php">Overview</a></li>

--- a/webpages/xsl/ParticipantMenu_BS4.xsl
+++ b/webpages/xsl/ParticipantMenu_BS4.xsl
@@ -13,9 +13,6 @@
   <xsl:param name="SessionInterests" select="'true'" />
   <xsl:template match="/">
     <nav id="participantNav" class="navbar navbar-expand-lg navbar-dark bg-dark mb-3">
-      <span class="navbar-brand py-1">
-        <xsl:value-of select="$title"/>
-      </span>
       <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent"
         aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon" />

--- a/webpages/xsl/StaffMenu.xsl
+++ b/webpages/xsl/StaffMenu.xsl
@@ -35,9 +35,6 @@
             <span class="icon-bar"/>
             <span class="icon-bar"/>
           </a>
-          <span class="brand inactive">
-            <xsl:value-of select="$title"/>
-          </span>
           <div class="nav-collapse">
             <ul class="nav">
               <li class="dropdown">

--- a/webpages/xsl/StaffMenu_BS4.xsl
+++ b/webpages/xsl/StaffMenu_BS4.xsl
@@ -44,9 +44,6 @@
                     </xsl:attribute>
                 </xsl:otherwise>
             </xsl:choose>
-            <a class="navbar-brand py-1" href="#">
-                <xsl:value-of select="$title"/>
-            </a>
             <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent"
                 aria-controls="navbarSupportedContent"
                 aria-expanded="false" aria-label="Toggle navigation">

--- a/webpages/xsl/StaffMenu_BS4.xsl
+++ b/webpages/xsl/StaffMenu_BS4.xsl
@@ -134,7 +134,7 @@
                 </ul>
                 <form method="post" action="ShowSessions.php" class="form-inline my-0 my-lg-0 mr-4">
                     <input type="text" id="searchtitle" name="searchtitle" size="28"
-                           class="form-control mr-sm-2 h-100 bg-secondary text-white"
+                           class="form-control form-control-sm mr-sm-2 h-100 bg-secondary text-white"
                            placeholder="Search for sessions by title" aria-label="Search"/>
                     <input type="hidden" value="ANY" name="track"/>
                     <input type="hidden" value="ANY" name="status"/>


### PR DESCRIPTION
Currently, the Nav bar  (the "menu" bar) shows the page name. At times, this page name takes up a non-trivial amount of screen real-estate and causes the nav bar to wrap (especially on narrower browser windows). But it doesn't provide a lot of value, as most pages have a header.

<img width="663" alt="Screen Shot 2023-04-08 at 8 28 06 AM" src="https://user-images.githubusercontent.com/2981347/230721470-3d1e8cee-1540-47d1-83e4-e765396ab51f.png">
<img width="452" alt="Screen Shot 2023-04-08 at 8 38 24 AM" src="https://user-images.githubusercontent.com/2981347/230721490-9bdd1a15-53cd-41c3-802e-5971fba2e546.png">
