### PR TITLE
Fix first interest not rendering on General Interests page

### DIFF
--- a/webpages/SubmitMyInterests.php
+++ b/webpages/SubmitMyInterests.php
@@ -33,7 +33,7 @@ for ($i = 0; $i < $rolerows; $i++) {
 $rolearray['count'] = $rolerows;
 
 $interestarray = array();
-for ($i = 1; $i < $interestrows; $i++) {
+for ($i = 0; $i < $interestrows; $i++) {
     $interestarray[$i] = array();
     if (isset($_POST["willdointerest" . $i])) {
         $interestarray[$i]["badgeid"] = $badgeid;
@@ -90,7 +90,7 @@ for ($i = 0; $i < $rolerows; $i++) {
     }
 }
 
-for ($i = 1; $i < $interestrows; $i++) {
+for ($i = 0; $i < $interestrows; $i++) {
     if (isset($interestarray[$i]["badgeid"]) && ($interestarray[$i]["diddointerest"] == 0)) {
         $query = "INSERT INTO ParticipantHasInterest set badgeid=\"" . $badgeid . "\", interestid=" . $interestarray[$i]["interestid"] . "";
         if (!mysqli_query($linki, $query)) {

--- a/webpages/renderMyInterests.php
+++ b/webpages/renderMyInterests.php
@@ -111,7 +111,7 @@ function renderMyInterests($title, $error, $message, $rolearray, $interestarray)
     echo "<p class=\"mt-3\">From which of the following areas would you consider being a panelist? (Check all that apply):</p>\n";
     echo "<div class=\"row mt-3\">\n";
     echo "    <div class=\"col-12 interests-list-container\">\n";
-    for ($i = 1; $i < $interestrows; $i++) {
+    for ($i = 0; $i < $interestrows; $i++) {
         echo "        <div class=\"interest-entry-container\">\n";
         echo "            <label for=\"willdointerest" . $i . "\">\n";
         echo "                <input type=\"checkbox\" name=\"willdointerest" . $i . "\" id=\"willdointerest" . $i . "\"";


### PR DESCRIPTION
For loop rendering Interests was 1-based rather than 0-based, causing first interest to be skipped.

This change simply starts For loop at 0 so all items are rendered.

Fixes #158.