### PR TITLE
Add check for applied patches to Staff Overview page

### DIFF
--- a/webpages/SiteHealth.php
+++ b/webpages/SiteHealth.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * Class for checking for site problems.
+ */
+class SiteHealth
+{
+    protected array $problems = [];
+
+    /**
+     * Check if patch file is loged in PatchLog table.
+     *
+     * @param string $fileName - The file to check if already run.
+     *
+     * @return bool
+     */
+    protected function checkPatchApplied(string $fileName): bool
+    {
+        $query = <<<EOF
+            SELECT count(1) AS `ct`
+                FROM PatchLog
+                WHERE patchname='$fileName';
+        EOF;
+        if (!$result = mysqli_query_exit_on_error($query)) {
+            exit(); // Should have exited already
+        }
+        [$count] = mysqli_fetch_array($result, MYSQLI_NUM);
+        mysqli_free_result($result);
+        return ($count == 1);
+    }
+
+    /**
+     * Check for files in the Upgrade_dbase directory, and verify against
+     * PatchLog.
+     *
+     * @return void
+     */
+    protected function findAndCheckPatches(): void
+    {
+        $directory = dir(dirname(__FILE__) . '/../Install/Upgrade_dbase');
+        while (false !== ($file = $directory->read())) {
+            if (preg_match('/\.sql$/', $file)) {
+                if (!$this->checkPatchApplied($file)) {
+                    // Patch file has not been applied.
+                    // Record problem and exit, as no need to check further.
+                    $this->problems[] = "Database patches need to be applied."
+                        . "Please see Install/INSTALL.md for details.";
+                    return;
+                }
+            }
+        }
+    }
+
+    /**
+     * Check the site site for problems.
+     *
+     * @return void
+     */
+    public function findSiteProblems(): void
+    {
+        $this->findAndCheckPatches();
+    }
+
+    /**
+     * Return a rendered string listing problems with the site.
+     *
+     * @return string
+     */
+    public function renderSiteStatus(): string
+    {
+        if (count($this->problems) == 0) {
+            return "<p>Site is healthy.</p>";
+        }
+
+        $text = "<p>This site has the following problems:</p>";
+        $text .= "<ul>";
+        foreach ($this->problems as $problem) {
+            $text .= "<li>$problem</li>";
+        }
+        $text .= "<p>Please contact your administrator to resolve.";
+
+        return $text;
+    }
+}

--- a/webpages/StaffPage.php
+++ b/webpages/StaffPage.php
@@ -4,6 +4,7 @@ global $participant, $message_error, $message2, $congoinfo, $title;
 $title = "Staff Overview";
 require_once('StaffCommonCode.php');
 require_once('con_data.php');
+require_once('SiteHealth.php');
 staff_header($title,  true);
 ?>
 
@@ -13,7 +14,7 @@ staff_header($title,  true);
     <div class="card-header">
         <h2><?php echo CON_NAME; ?></h2>
         <p>
-<?php 
+<?php
         $conData = ConData::fromEnvironmentDefinition();
         echo $conData->startDate->format('D, j M Y');
         echo ' - ';
@@ -79,6 +80,24 @@ echo "    </div><!-- close card body -->\n";
 
 ?>
 </p>
+</div><!-- close card top level -->
+
+</div>
+</div>
+
+<div class="row">
+<div class="col-lg-8">
+<div class="card mt-2">
+    <div class="card-header">
+        <h5><?php echo CON_NAME; ?> Status</h5>
+    </div>
+    <div class="card-body">
+<?php
+    $healthCheck = new SiteHealth;
+    $healthCheck->findSiteProblems();
+    echo $healthCheck->renderSiteStatus();
+?>
+    </div><!-- close card body -->
 </div><!-- close card top level -->
 
 </div>


### PR DESCRIPTION
This change adds a check to the Staff Overview page, and displays the site health status in a new panel.

Currently it only checks for unapplied database patches, but my intention is to add additional checks for common site problems.

This is the first step of implementing #163.

This should make it a lot harder for unapplied site patches to be missed, so I think this should allow #121 to be closed.