### PR TITLE
Add check report menu build status

### DIFF
--- a/webpages/SiteHealth.php
+++ b/webpages/SiteHealth.php
@@ -5,6 +5,12 @@
  */
 class SiteHealth
 {
+    private const UPGRADE_PATH = '/../Install/Upgrade_dbase';
+    private const REPORTS_BS4_INCLUDE = 'ReportMenuBS4Include.php';
+    private const REPORTS_INCLUDE = 'ReportMenuInclude.php';
+    private const STAFF_REPORTS_INCLUDE = 'staffReportsInCategoryInclude.php';
+    private const REPORTS_PATH = './reports';
+
     protected array $problems = [];
 
     /**
@@ -37,18 +43,66 @@ class SiteHealth
      */
     protected function findAndCheckPatches(): void
     {
-        $directory = dir(dirname(__FILE__) . '/../Install/Upgrade_dbase');
+        $directory = dir(dirname(__FILE__) . self::UPGRADE_PATH);
         while (false !== ($file = $directory->read())) {
             if (preg_match('/\.sql$/', $file)) {
                 if (!$this->checkPatchApplied($file)) {
                     // Patch file has not been applied.
                     // Record problem and exit, as no need to check further.
-                    $this->problems[] = "Database patches need to be applied."
-                        . "Please see Install/INSTALL.md for details.";
+                    $this->problems[] =
+                        "Database patches need to be applied. " .
+                        "Please see Install/INSTALL.md for details.";
                     return;
                 }
             }
         }
+    }
+
+    /**
+     * Check the report directory files exist, and that they are newer than the
+     * newest report files.
+     *
+     * @return void
+     */
+    protected function checkReportMenus(): void
+    {
+        // First make sure the three include files exist.
+        if (!(
+            file_exists(REPORT_INCLUDE_DIRECTORY . self::REPORTS_BS4_INCLUDE) &&
+            file_exists(REPORT_INCLUDE_DIRECTORY . self::REPORTS_INCLUDE) &&
+            file_exists(REPORT_INCLUDE_DIRECTORY . self::STAFF_REPORTS_INCLUDE)
+        )) {
+            $this->problems[] =
+                "Report menus have not been built. " .
+                "Ask your admin to build them.";
+        }
+
+        // Get the oldest creation date of the include files.
+        $min_date = min(
+            filemtime(REPORT_INCLUDE_DIRECTORY . self::REPORTS_BS4_INCLUDE),
+            filemtime(REPORT_INCLUDE_DIRECTORY . self::REPORTS_INCLUDE),
+            filemtime(REPORT_INCLUDE_DIRECTORY . self::STAFF_REPORTS_INCLUDE),
+        );
+
+        // Check files in reports directory against menu creation date.
+        $path = dirname(__FILE__) . '/' . self::REPORTS_PATH;
+        $directory = dir($path);
+        while (false !== ($file = $directory->read())) {
+            if (preg_match('/\.php$/', $file)) {
+                $report_date = filemtime($path . '/' . $file);
+                if ($report_date > $min_date) {
+                    $this->problems[] =
+                        "Report menus were last build on date " .
+                        date("Y-m-d", $min_date) .
+                        " but report found with date of " .
+                        date("Y-m-d", $report_date) .
+                        ". Ask your admin to rebuild the menus.";
+                    // Once we know rebuild needed, no need to check further.
+                    return;
+                }
+            }
+        }
+
     }
 
     /**
@@ -59,6 +113,7 @@ class SiteHealth
     public function findSiteProblems(): void
     {
         $this->findAndCheckPatches();
+        $this->checkReportMenus();
     }
 
     /**
@@ -77,6 +132,7 @@ class SiteHealth
         foreach ($this->problems as $problem) {
             $text .= "<li>$problem</li>";
         }
+        $text .= "</ul>";
         $text .= "<p>Please contact your administrator to resolve.";
 
         return $text;


### PR DESCRIPTION
This change checks if the report menus have been built, or if a rebuild might be needed.

First, it checks for the presence of the three report menu include files. If any are missing, it will alert that the report menus have not been built.

Then it gets the timestamp of the oldest of the three include files. Using this, it loops through all files in the reports directory, and checks if any are newer than the include files. If any newer report files are found, an alert will be displayed.

This could be considered overkill, since it may be an existing report that has been modified, and not all changes require a rebuild. However, this seems a minor inconvenience, since reports won't change very often, and rebuilding the menus is not a difficult process.

This includes some other minor changes to the SiteHealth class, such as moving the database upgrade path into a constant.

This is another part of #163.