### PR TITLE
Table Editor message for required fields, and prepopulate defaults

### DIFF
--- a/webpages/SubmitEditConfigTable.php
+++ b/webpages/SubmitEditConfigTable.php
@@ -32,7 +32,7 @@ function fetch_schema($tablename) {
         // json of schema and table contents
         $query=<<<EOD
     SELECT
-        COLUMN_NAME, DATA_TYPE, CHARACTER_MAXIMUM_LENGTH, COLUMN_KEY, EXTRA
+        COLUMN_NAME, DATA_TYPE, CHARACTER_MAXIMUM_LENGTH, COLUMN_KEY, COLUMN_DEFAULT, IS_NULLABLE, EXTRA
     FROM
         INFORMATION_SCHEMA.COLUMNS
     WHERE
@@ -215,7 +215,7 @@ function update_table($tablename)
 }
 
 /*
- *  Return the name of the first column ending with "name" on the table. 
+ *  Return the name of the first column ending with "name" on the table.
  */
 function lookupNameColumn($tableName)
 {
@@ -239,7 +239,7 @@ EOD;
 }
 
 /*
- *  Return the name of the first column of type "varchar" on the table. 
+ *  Return the name of the first column of type "varchar" on the table.
  */
 function lookupVarcharColumn($tableName)
 {
@@ -361,7 +361,7 @@ EOD;
             else
                 $joinclause .= "$union SELECT '$reftable', $reffield, COUNT(*) AS occurs FROM $reftable GROUP BY $curfield\n";
             $union = "UNION ALL";
-        }        
+        }
         if (DBVER >= "8") {
             $withclause .= "), SUM$curfield AS (\nSELECT $curfield, SUM(occurs) AS occurs FROM Ref$curfield GROUP BY $curfield\n)\n";
             $joinclause .= "LEFT OUTER JOIN SUM$curfield ON ($tablename.$mycurname = SUM$curfield.$curfield)\n";

--- a/webpages/xsl/ConfigTableEditor.xsl
+++ b/webpages/xsl/ConfigTableEditor.xsl
@@ -817,6 +817,7 @@
                         </div>
                     </div>
                 </div>
+                <div id="table-required"></div>
                 <div class="row mt-4">
                     <div class="col col-auto">
                         <button class="btn btn-secondary" id="undo" name="undo" value="undo" type="button"


### PR DESCRIPTION
This change should improve the experience when editing any tables with required fields.

First in `SubmitEditConfigTable.php`, I've added `COLUMN_DEFAULT` and `IS_NULLABLE` to the table schema information returned from Ajax calls.

In `ConfigTableEditor.xsl`, I've added a new `<div>` called `table-required` to display a list of required fields for the table. During table load, a list of fields where `IS_NULLABLE` is built, and displayed here. If no fields in the list, it is set to blank. The key field and `display_order` are never added to this list, as they aren't normally seen by the user.

When "Add New" is pressed, the field list is traversed, and any fields with a value in `COLUMN_DEFAULT` are added to the row added to the row object passed to the grid. String values come wrapped the quotes, so quotes are stripped. This could potentially lead to an edge case where escaped quotes in a default value get lost, but this seems such an unlikely case that I didn't make any provision for it.

It turns out there are quite a few tables that have required fields, but in most they are fields you would be unlikely to leave empty. `Rooms` is fairly unique because it has a lot of required fields, and they come after mostly optional ones, and it's far from obvious which fields are required.

Populating default values goes a long way to mitigating the problem, particularly for the Rooms table, where all the required fields have defaults.

This goes a long way to mitigating the problems in issue #162, though it would be good if it prevented you from saving while a required column wasn't populated.