### PR TITLE
Add Live Stream and Recording Permission Questions

### DIFF
--- a/Install/Upgrade_dbase/99ZED_add_streaming_and_recording.sql
+++ b/Install/Upgrade_dbase/99ZED_add_streaming_and_recording.sql
@@ -1,0 +1,24 @@
+## This script adds tech streaming and recording permissions for participants.
+##
+##	Created by James Shields on 2024-01-10
+## 	Copyright (c) 2020 by Peter Olszowka. All rights reserved. See copyright document for more details.
+##
+
+ALTER TABLE Participants
+    ADD column allow_recording tinyint(1) AFTER use_photo,
+    ADD column allow_streaming tinyint(1) AFTER use_photo;
+
+UPDATE Participants SET share_email = 2 where share_email =0;
+UPDATE Participants SET use_photo = 2 where use_photo =0;
+
+INSERT INTO PermissionAtoms(permatomid, permatomtag, page, notes)
+VALUES
+    (2066, 'EditUserPermissions', 'Administer Participants', 'enables editing of permissions like interested in participating, recording, streaming, etc');
+
+INSERT INTO Permissions(permatomid, phaseid, permroleid)
+SELECT a.permatomid, null, r.permroleid
+FROM PermissionAtoms a
+JOIN PermissionRoles r ON (r.permrolename IN ('Administrator', 'Senior Staff'))
+WHERE permatomtag IN ('EditUserPermissions');
+
+INSERT INTO PatchLog (patchname) VALUES ('99ZED_add_streaming_and_recording.sql');

--- a/webpages/AdminParticipants.php
+++ b/webpages/AdminParticipants.php
@@ -9,6 +9,7 @@ staff_header($title, $bootstrap4);
 if ($fbadgeid) {
     echo "<script type=\"text/javascript\">fbadgeid = $fbadgeid;</script>\n";
 }
+$allowEditPermission = may_I('EditUserPermissions') ? 'yes' : 'no';
 ?>
 <form id="adminParticipantsForm">
 <div class="card">
@@ -35,6 +36,7 @@ if ($fbadgeid) {
                 </div>
             </div>
         </div>
+        <input type="hidden" id="allow-edit-permission" value="<?= $allowEditPermission ?>" />
         <div style="margin-top: 1em; height:250px; overflow:auto; border: 1px solid grey" id="searchResultsDIV">&nbsp;
         </div>
     </div>
@@ -214,19 +216,68 @@ if (USE_REG_SYSTEM === FALSE) {
     </div>
 <?php
 };
-?>
 
-        <div class="container-sm py-2 px-3 my-3 border border-dark rounded">
+    function yesNoSelectBlock(string $id, string $label, string $help_text = '', bool $display = true) {
+        if ($display) {
+?>
             <div class="form-group">
-                <label for="interested" class="control-label">Participant is interested and available to participate
-                    in <?php echo CON_NAME; ?> programming:</label>
-                <select id="interested" class="yesno mycontrol form-control" disabled="disabled" style="width: auto;">
+                <label for="<?= $id ?>" class="control-label"><?= $label ?></label>
+                <select id="<?= $id ?>" class="yesno mycontrol form-control" disabled="disabled" style="width: auto;">
                     <option value="0" selected="selected">&nbsp</option>
                     <option value="1">Yes</option>
                     <option value="2">No</option>
                 </select>
-                <p class="help-block">Changing this to <i>No</i> will remove the participant from all sessions.</p>
-            </div>
+<?php
+            if ($help_text) {
+?>
+            <p class="help-block"><?= $help_text ?></p>
+<?php
+            }
+?>
+        </div>
+<?php
+        }
+        else {
+?>
+            <input type="hidden" id="<?= $id ?>" />
+<?php
+        }
+    }
+?>
+
+        <div class="container-sm py-2 px-3 my-3 border border-dark rounded">
+            <p id="permission-disabled"><strong>Note:</strong> You are not allowed to edit this section.</p>
+<?php
+    yesNoSelectBlock(
+        'interested',
+        'Participant is interested and available to participate in ' . CON_NAME . ' programming',
+        'Changing this to <em>No</em> will remove the participant from all sessions.',
+    );
+    yesNoSelectBlock(
+        'share_email',
+        'Participant gives permission to share email with other participants',
+        '',
+        ENABLE_SHARE_EMAIL_QUESTION,
+    );
+    yesNoSelectBlock(
+        'use_photo',
+        'Participant gives permission to use photos in promotion of the convention',
+        '',
+        ENABLE_USE_PHOTO_QUESTION,
+    );
+    yesNoSelectBlock(
+        'allow_streaming',
+        'Participant gives permission to live stream sessions',
+        '',
+        ENABLE_ALLOW_STREAMING_QUESTION,
+    );
+    yesNoSelectBlock(
+        'allow_recording',
+        'Participant gives permission to record sessions and make available for catchup',
+        '',
+        ENABLE_ALLOW_RECORDING_QUESTION,
+    );
+?>
         </div>
 
 <?php

--- a/webpages/PartSearchSessions.php
+++ b/webpages/PartSearchSessions.php
@@ -14,9 +14,9 @@ if (!may_I('search_panels')) {
     }
 
 $queryArray = array();
-$queryArray['interested'] = <<<EOD
+$queryArray['participant'] = <<<EOD
 SELECT
-        P.interested
+        P.interested, share_email, use_photo, allow_streaming, allow_recording
     FROM
         Participants P
     WHERE
@@ -55,6 +55,10 @@ $paramArray["conName"] = CON_NAME;
 $paramArray["showTags"] = TRACK_TAG_USAGE !== "TRACK_ONLY";
 $paramArray["showTrack"] = TRACK_TAG_USAGE !== "TAG_ONLY";
 $paramArray["PARTICIPANT_PHOTOS"] = PARTICIPANT_PHOTOS === TRUE ? 1 : 0;
+$paramArray["ENABLE_SHARE_EMAIL_QUESTION"] = ENABLE_SHARE_EMAIL_QUESTION ? 1 : 0;
+$paramArray["ENABLE_USE_PHOTO_QUESTION"] = ENABLE_USE_PHOTO_QUESTION ? 1 : 0;
+$paramArray["ENABLE_ALLOW_STREAMING_QUESTION"] = ENABLE_ALLOW_STREAMING_QUESTION ? 1 : 0;
+$paramArray["ENABLE_ALLOW_RECORDING_QUESTION"] = ENABLE_ALLOW_RECORDING_QUESTION ? 1 : 0;
 // echo(mb_ereg_replace("<(row|query)([^>]*/[ ]*)>", "<\\1\\2></\\1>", $resultXML->saveXML(), "i")); //for debugging only
 RenderXSLT('PartSearchSessions.xsl', $paramArray, $resultXML);
 

--- a/webpages/PartSearchSessionsSubmit.php
+++ b/webpages/PartSearchSessionsSubmit.php
@@ -84,9 +84,9 @@ if ($tagArr !== false && count($tagArr) > 0 && TRACK_TAG_USAGE !== "TRACK_ONLY")
     }
 }
 $queryArray["sessions"] .= ") GROUP BY S.sessionid ORDER BY $addtrack S.sessionid;";
-$queryArray["interested"] = <<<EOD
+$queryArray['participant'] = <<<EOD
 SELECT
-        P.interested
+        P.interested, share_email, use_photo, allow_streaming, allow_recording
     FROM
         Participants P
     WHERE
@@ -113,6 +113,10 @@ $paramArray["trackIsPrimary"] = TRACK_TAG_USAGE === "TRACK_ONLY" || TRACK_TAG_US
 $paramArray["showTrack"] = TRACK_TAG_USAGE !== "TAG_ONLY";
 $paramArray["showTags"] = TRACK_TAG_USAGE !== "TRACK_ONLY";
 $paramArray["collapse_list"] = $collapse_list;
+$paramArray["ENABLE_SHARE_EMAIL_QUESTION"] = ENABLE_SHARE_EMAIL_QUESTION ? 1 : 0;
+$paramArray["ENABLE_USE_PHOTO_QUESTION"] = ENABLE_USE_PHOTO_QUESTION ? 1 : 0;
+$paramArray["ENABLE_ALLOW_STREAMING_QUESTION"] = ENABLE_ALLOW_STREAMING_QUESTION ? 1 : 0;
+$paramArray["ENABLE_ALLOW_RECORDING_QUESTION"] = ENABLE_ALLOW_RECORDING_QUESTION ? 1 : 0;
 
 participant_header($title, false, 'Normal', true);
 echo(mb_ereg_replace("<(row|query)([^>]*/[ ]*)>", "<\\1\\2></\\1>", $resultXML->saveXML(), "i")); //for debugging only

--- a/webpages/SubmitMyContact.php
+++ b/webpages/SubmitMyContact.php
@@ -30,7 +30,7 @@ function update_participant($badgeid) {
     }
     if (isset($_POST['share_email'])) {
         $x = $_POST['share_email'];
-        if ($x == 0 || $x == 1) {
+        if ($x == 1 || $x == 2) {
             $updateClause .= "share_email=$x, ";
         } else {
             $updateClause .= "share_email=null, ";
@@ -38,10 +38,26 @@ function update_participant($badgeid) {
     }
     if (isset($_POST['use_photo'])) {
         $x = $_POST['use_photo'];
-        if ($x == 0 || $x == 1) {
+        if ($x == 1 || $x == 2) {
             $updateClause .= "use_photo=$x, ";
         } else {
             $updateClause .= "use_photo=null, ";
+        }
+    }
+    if (isset($_POST['allow_streaming'])) {
+        $x = $_POST['allow_streaming'];
+        if ($x == 1 || $x == 2) {
+            $updateClause .= "allow_streaming=$x, ";
+        } else {
+            $updateClause .= "allow_streaming=null, ";
+        }
+    }
+    if (isset($_POST['allow_recording'])) {
+        $x = $_POST['allow_recording'];
+        if ($x == 1 || $x == 2) {
+            $updateClause .= "allow_recording=$x, ";
+        } else {
+            $updateClause .= "allow_recording=null, ";
         }
     }
     if (isset($_POST['bestway'])) {

--- a/webpages/config/db_name_sample.php
+++ b/webpages/config/db_name_sample.php
@@ -41,6 +41,8 @@ define("MAX_BIO_LEN", 1000); // Maximum length (in characters) permitted for par
 define("MY_AVAIL_KIDS", FALSE); // Enables questions regarding no. of kids in Fasttrack on "My Availability"
 define("ENABLE_SHARE_EMAIL_QUESTION", TRUE); // Enables question regarding sharing participant email address
 define("ENABLE_USE_PHOTO_QUESTION", TRUE); // Enables question regarding using participant photo for promotional purposes
+define("ENABLE_ALLOW_STREAMING_QUESTION", TRUE); // Enables question asking if participant is willing to be streamed on sessions.
+define("ENABLE_ALLOW_RECORDING_QUESTION", TRUE); // Enables question asking if participant is willing to be recorded for playback sessions.
 define("ENABLE_BESTWAY_QUESTION", FALSE); // Enables question regarding best way to contact participant
 define("TITLE_MIN_LENGTH", 10); // Title must be at least this long.
 define("TITLE_MAX_LENGTH", 50); // Title must not be longer than this. Note that the current limit of the DB field is 100 characters.

--- a/webpages/data_functions.php
+++ b/webpages/data_functions.php
@@ -74,7 +74,7 @@ function getInt($name, $default = false) {
         return $default;
     }
     $t = filter_var($int, FILTER_SANITIZE_NUMBER_INT);
-    if (empty($t) && $t !== 0) {
+    if (empty($t) && $t !== 0 && $t !== '0') {
         return $default;
     } else {
         return(intval($t));

--- a/webpages/db_functions.php
+++ b/webpages/db_functions.php
@@ -315,7 +315,7 @@ function prepare_db_and_more() {
  *  $query_param_type_str -- string of parameter types to be sent to prepared statement executor
  */
 function push_query_arrays($value, $field_name, $param_type, $max_len, &$query_portion_arr, &$query_param_arr, &$query_param_type_str) {
-    if (!empty($value) || $value === '') {
+    if (!empty($value) || $value === 0 || $value === '') {
         if ($param_type === 's' && mb_strlen($value) > $max_len && $max_len !== 0) {
             $message_error = "$field_name field is greater than maximum length of $max_len.  Db not updated.";
             RenderErrorAjax($message_error);

--- a/webpages/js/AdminParticipants.js
+++ b/webpages/js/AdminParticipants.js
@@ -5,6 +5,10 @@ var htmlbioused = false;
 var emailDirty = false;
 var firstnameDirty = false;
 var interestedDirty = false;
+var shareEmailDirty = false;
+var usePhotoDirty = false;
+var allowStreamingDirty = false;
+var allowRecordingDirty = false;
 var lastnameDirty = false;
 var passwordDirtyAndReady = false;
 var phoneDirty = false;
@@ -19,6 +23,10 @@ var sortedpubsnameDirty = false;
 var rolesDirty = false;
 var staffnotesDirty = false;
 var originalInterested = "0";
+var originalShareEmail = "0";
+var originalUsePhoto = "0";
+var originalAllowStreaming = "0";
+var originalAllowRecording = "0";
 var fbadgeid;
 var curbadgeid;
 var resultsHidden = true;
@@ -26,6 +34,10 @@ var max_bio_len = 500;
 var mce_running = false;
 var bio_updated = false;
 var $interested;
+var $shareEmail;
+var $usePhoto;
+var $allowStreaming;
+var $allowRecording;
 var $bio;
 var $htmlbio;
 var $password;
@@ -62,7 +74,8 @@ function isDirty(override) {
     if (override === undefined) {
         override = false;
     }
-    if (!override && (badgenameDirty || bioDirty || emailDirty || firstnameDirty || interestedDirty || lastnameDirty ||
+    if (!override && (badgenameDirty || bioDirty || emailDirty || firstnameDirty || interestedDirty ||
+        usePhotoDirty || shareEmailDirty || allowStreamingDirty || allowRecordingDirty || lastnameDirty ||
         $password.val() || phoneDirty || postaddress1Dirty || postaddress2Dirty || postcityDirty || poststateDirty ||
         postzipDirty || postcountryDirty || pubsnameDirty || sortedpubsnameDirty || rolesDirty || staffnotesDirty)) {
         $("#unsavedWarningModal").modal('show');
@@ -110,6 +123,7 @@ function chooseParticipant(badgeid, override) {
         if ($nextBTN)
             $nextBTN.disabled = searchIndex == (badgeList.length - 1);
     }
+    const disableEditPermission = $("#allow-edit-permission").val() === "no";
     $("#badgeid").val($("#bidSPAN_" + badgeidJQSel).text());
     var lastname = $("#lastnameHID_" + badgeidJQSel).val();
     $lastname.val(lastname).prop("defaultValue", lastname).prop("readOnly", false);
@@ -148,12 +162,22 @@ function chooseParticipant(badgeid, override) {
     $('#regtype').html(regtype);
     $('#warnName').html(pubsname);
     $('#warnNewBadgeID').html(badgeid);
-    originalInterested = $("#interestedHID_" + badgeidJQSel).val();
-    if (!originalInterested) {
-        originalInterested = "0";
-    }
+    $("#permission-disabled").prop("hidden", !disableEditPermission);
+    originalInterested = $("#interestedHID_" + badgeidJQSel).val() ?? "0";
     $interested.val(originalInterested);
-    $interested.prop("disabled", false);
+    $interested.prop("disabled", disableEditPermission);
+    originalShareEmail = $("#shareEmailHID_" + badgeidJQSel).val() ?? "0";
+    $shareEmail.val(originalShareEmail);
+    $shareEmail.prop("disabled", disableEditPermission);
+    originalUsePhoto = $("#usePhotoHID_" + badgeidJQSel).val() ?? "0";
+    $usePhoto.val(originalUsePhoto);
+    $usePhoto.prop("disabled", disableEditPermission);
+    originalAllowStreaming = $("#allowStreamingHID_" + badgeidJQSel).val() ?? "0";
+    $allowStreaming.val(originalAllowStreaming);
+    $allowStreaming.prop("disabled", disableEditPermission);
+    originalAllowRecording = $("#allowRecordingHID_" + badgeidJQSel).val() ?? "0";
+    $allowRecording.val(originalAllowRecording);
+    $allowRecording.prop("disabled", disableEditPermission);
     var bio = $("#bioHID_" + badgeidJQSel).val();
     var htmlbio = $("#htmlbioHID_" + badgeidJQSel).val();
     if (htmlbioused)
@@ -170,6 +194,10 @@ function chooseParticipant(badgeid, override) {
     emailDirty = false;
     firstnameDirty = false;
     interestedDirty = false;
+    shareEmailDirty = false;
+    usePhotoDirty = false;
+    allowStreamingDirty = false;
+    allowRecordingDirty = false;
     lastnameDirty = false;
     passwordDirtyAndReady = false;
     phoneDirty = false;
@@ -300,11 +328,22 @@ function fetchParticipantCallback(data, textStatus, jqXHR) {
     $sortedpubsname.val(node.getAttribute("sortedpubsname")).prop("defaultValue", node.getAttribute("sortedpubsname")).prop("readOnly", false);
     $answercount.val(node.getAttribute("answercount")).prop("defaultValue", node.getAttribute("answercount")).prop("readOnly", false);
     //console.log("hh" + answercount);
-    originalInterested = node.getAttribute("interested");
-    if (!originalInterested)
-        originalInterested = 0;
+    $("#permission-disabled").prop("hidden", !disableEditPermission);
+    originalInterested = node.getAttribute("interested") ?? 0;
     $interested.val(originalInterested);
-    $interested.prop("disabled", false);
+    $interested.prop("disabled", disableEditPermission);
+    originalShareEmail = node.getAttribute("share_email") ?? 0;
+    $shareEmail.val(originalShareEmail);
+    $shareEmail.prop("disabled", disableEditPermission);
+    originalUsePhoto = node.getAttribute("use_photo") ?? 0;
+    $usePhoto.val(originalUsePhoto);
+    $usePhoto.prop("disabled", disableEditPermission);
+    originalAllowStreaming = node.getAttribute("allow_streaming") ?? 0;
+    $allowStreaming.val(originalAllowStreaming);
+    $allowStreaming.prop("disabled", disableEditPermission);
+    originalAllowRecording = node.getAttribute("allow_recording") ?? 0;
+    $allowRecording.val(originalAllowRecording);
+    $allowRecording.prop("disabled", disableEditPermission);
     $bio.val(node.getAttribute("bio")).prop("defaultValue", node.getAttribute("bio"));
     if (htmlbioused) {
         $htmlbio.val(node.getAttribute("htmlbio")).prop("defaultValue", node.getAttribute("htmlbio"));
@@ -325,6 +364,10 @@ function fetchParticipantCallback(data, textStatus, jqXHR) {
     emailDirty = false;
     firstnameDirty = false;
     interestedDirty = false;
+    shareEmailDirty = false;
+    usePhotoDirty = false;
+    allowStreamingDirty = false;
+    allowRecordingDirty = false;
     lastnameDirty = false;
     passwordDirtyAndReady = false;
     phoneDirty = false;
@@ -394,7 +437,12 @@ function hideSearchResults() {
 function initializeAdminParticipants() {
     //called when JQuery says AdminParticipants page has loaded
     //debugger;
+    const disableEditPermission = $("#allow-edit-permission").val() === "no";
     $interested = $("#interested");
+    $shareEmail = $("#share_email")
+    $usePhoto = $("#use_photo");
+    $allowStreaming = $("#allow_streaming");
+    $allowRecording = $("#allow_recording");
     $bio = $("#bio");
     $avatar = $("#participantAvatar");
     $htmlbio = $("#htmlbio");
@@ -469,6 +517,18 @@ function processChange() {
         case 'interested':
             interestedDirty = ($interested.val() !== originalInterested);
             break;
+        case 'share_email':
+            shareEmailDirty = ($shareEmail.val() !== originalShareEmail);
+            break;
+        case 'use_photo':
+            usePhotoDirty = ($usePhoto.val() !== originalUsePhoto);
+            break;
+        case 'allow_streaming':
+            allowStreamingDirty = ($allowStreaming.val() !== originalAllowStreaming);
+            break;
+        case 'allow_recording':
+            allowRecordingDirty = ($allowRecording.val() !== originalAllowRecording);
+            break;
         case 'bio':
             bioDirty = ($bio.val() !== $bio.prop("defaultValue"));
             break;
@@ -533,7 +593,8 @@ function processChange() {
 }
 
 function checkDirty() {
-    if (passwordDirtyAndReady || interestedDirty || bioDirty || staffnotesDirty || pubsnameDirty || sortedpubsnameDirty || lastnameDirty ||
+    if (passwordDirtyAndReady || interestedDirty || shareEmailDirty || usePhotoDirty || allowStreamingDirty ||
+        allowRecordingDirty || bioDirty || staffnotesDirty || pubsnameDirty || sortedpubsnameDirty || lastnameDirty ||
         firstnameDirty || badgenameDirty || phoneDirty || emailDirty || postaddress1Dirty || postaddress2Dirty ||
         postcityDirty || poststateDirty || postzipDirty || postcountryDirty || rolesDirty) {
 
@@ -570,12 +631,17 @@ function showSearchResults() {
 }
 
 function showUpdateResults(data, textStatus, jqXHR) {
+
     //ajax success callback function
     badgenameDirty = false;
     bioDirty = false;
     emailDirty = false;
     firstnameDirty = false;
     interestedDirty = false;
+    shareEmailDirty = false;
+    usePhotoDirty = false;
+    allowStreamingDirty = false;
+    allowRecordingDirty = false;
     lastnameDirty = false;
     passwordDirtyAndReady = false;
     phoneDirty = false;
@@ -594,6 +660,10 @@ function showUpdateResults(data, textStatus, jqXHR) {
     $('#updateBUTN').button('reset');
     $updateButton.prop("disabled", true);
     originalInterested = $interested.val();
+    originalShareEmail = $shareEmail.val();
+    originalUsePhoto = $usePhoto.val();
+    originalAllowStreaming = $allowStreaming.val();
+    originalAllowRecording = $allowRecording.val();
     // update the selection list
     var node = data.firstChild.firstChild.firstChild;
     var retbadgeid = node.getAttribute("badgeid");
@@ -614,6 +684,11 @@ function showUpdateResults(data, textStatus, jqXHR) {
     $("#spnameHID_" + badgeidJQSel).val(node.getAttribute("sortedpubsname"));
     $("#bnameSPAN_" + badgeidJQSel).html(node.getAttribute("badgename"));
     $("#interestedHID_" + badgeidJQSel).originalInterested = node.getAttribute("interested");
+    $("#shareEmailHID_" + badgeidJQSel).originalShareEmail = node.getAttribute("share_email");
+    $("#usePhotoHID_" + badgeidJQSel).originalUsePhoto = node.getAttribute("use_photo");
+    $("#allowStreamingHID_" + badgeidJQSel).originalAllowStreaming = node.getAttribute("allow_streaming");
+    $("#allowRecordingHID_" + badgeidJQSel).originalAllowRecording = node.getAttribute("allow_recording");
+    disableEditPermission = node.getAttribute("allow_edit_permission") === 'yes' ? false : true;
     $("#bioHID_" + badgeidJQSel).val(node.getAttribute("bio"));
     if (htmlbioused) {
         $("#htmlbioHID_" + badgeidJQSel).val(node.getAttribute("htmlbio"));
@@ -661,6 +736,18 @@ function updateBUTTON() {
     }
     if (interestedDirty) {
         postdata.interested = $interested.val();
+    }
+    if (shareEmailDirty) {
+        postdata.share_email = $shareEmail.val();
+    }
+    if (usePhotoDirty) {
+        postdata.use_photo = $usePhoto.val();
+    }
+    if (allowStreamingDirty) {
+        postdata.allow_streaming = $allowStreaming.val();
+    }
+    if (allowRecordingDirty) {
+        postdata.allow_recording = $allowRecording.val();
     }
     if (lastnameDirty) {
         postdata.lastname = $lastname.val();

--- a/webpages/my_contact.php
+++ b/webpages/my_contact.php
@@ -10,7 +10,7 @@ SELECT
         CD.badgeid, CD.firstname, CD.lastname, CD.badgename, CD.phone, CD.email,
         CD.postaddress1, CD.postaddress2, CD.postcity, CD.poststate, CD.postzip,
         CD.postcountry, $regTypeField, P.pubsname, P.sortedpubsname, P.password, P.bestway, P.interested, P.bio,
-        P.htmlbio, P.share_email, P.use_photo, PRO.pronounname, P.approvedphotofilename,
+        P.htmlbio, P.share_email, P.use_photo, P.allow_streaming, P.allow_recording, PRO.pronounname, P.approvedphotofilename,
         P.anonymous
     FROM
        CongoDump CD
@@ -42,6 +42,8 @@ $paramArray = array();
 $paramArray['conName'] = CON_NAME;
 $paramArray['enableShareEmailQuestion'] = ENABLE_SHARE_EMAIL_QUESTION ? 1 : 0;
 $paramArray['enableUsePhotoQuestion'] = ENABLE_USE_PHOTO_QUESTION ? 1 : 0;
+$paramArray['enableStreamingQuestion'] = defined('ENABLE_ALLOW_STREAMING_QUESTION') && ENABLE_ALLOW_STREAMING_QUESTION ? 1 : 0;
+$paramArray['enableRecordingQuestion'] = defined('ENABLE_ALLOW_RECORDING_QUESTION') && ENABLE_ALLOW_RECORDING_QUESTION ? 1 : 0;
 $paramArray['enableBestwayQuestion'] = ENABLE_BESTWAY_QUESTION ? 1 : 0;
 $paramArray['useRegSystem'] = USE_REG_SYSTEM ? 1 : 0;
 $paramArray['maxBioLen'] = MAX_BIO_LEN;

--- a/webpages/reports/attending.php
+++ b/webpages/reports/attending.php
@@ -10,6 +10,10 @@ $report['columns'] = array(
     null,
     null,
     null,
+    null,
+    null,
+    null,
+    null,
     null
 );
 $report['queries'] = [];
@@ -19,7 +23,11 @@ SELECT
         CD.lastname,
         P.pubsname,
         P.badgeid,
-        P.interested
+        P.interested,
+        P.share_email,
+        P.use_photo,
+        P.allow_streaming,
+        P.allow_recording
     FROM
              Participants P
         JOIN CongoDump CD USING (badgeid)
@@ -42,8 +50,12 @@ $report['xsl'] =<<<'EOD'
                         <tr style="height:2.6rem">
                             <th class="report">Registration Name</th>
                             <th class="report">Pubs Name</th>
-                        <th class="report">Person ID</th>
+                            <th class="report">Person ID</th>
                             <th class="report"><xsl:text disable-output-escaping="yes">Interested &amp;amp; Attending</xsl:text></th>
+                            <th class="report">May share email</th>
+                            <th class="report">May use photo</th>
+                            <th class="report">Allow streaming</th>
+                            <th class="report">Allow recording</th>
                         </tr>
                     </thead>
                     <xsl:apply-templates select="/doc/query[@queryName='participants']/row"/>
@@ -67,6 +79,34 @@ $report['xsl'] =<<<'EOD'
                     <xsl:when test="@interested='1'">Yes</xsl:when>
                     <xsl:when test="@interested='2'">No</xsl:when>
                     <xsl:otherwise>Didn't log in</xsl:otherwise>
+                </xsl:choose>
+            </td>
+            <td class="report">
+                <xsl:choose>
+                    <xsl:when test="@share_email='1'">Yes</xsl:when>
+                    <xsl:when test="@share_email='2'">No</xsl:when>
+                    <xsl:otherwise>Didn't respond</xsl:otherwise>
+                </xsl:choose>
+            </td>
+            <td class="report">
+                <xsl:choose>
+                    <xsl:when test="@use_photo='1'">Yes</xsl:when>
+                    <xsl:when test="@use_photo='2'">No</xsl:when>
+                    <xsl:otherwise>Didn't respond</xsl:otherwise>
+                </xsl:choose>
+            </td>
+            <td class="report">
+                <xsl:choose>
+                    <xsl:when test="@allow_streaming='1'">Yes</xsl:when>
+                    <xsl:when test="@allow_streaming='2'">No</xsl:when>
+                    <xsl:otherwise>Didn't respond</xsl:otherwise>
+                </xsl:choose>
+            </td>
+            <td class="report">
+                <xsl:choose>
+                    <xsl:when test="@allow_recording='1'">Yes</xsl:when>
+                    <xsl:when test="@allow_recording='2'">No</xsl:when>
+                    <xsl:otherwise>Didn't respond</xsl:otherwise>
                 </xsl:choose>
             </td>
         </tr>

--- a/webpages/reports/not_used_reports/configurable_report_sample.php
+++ b/webpages/reports/not_used_reports/configurable_report_sample.php
@@ -43,7 +43,7 @@ $report['xsl'] =<<<'EOD'
             </xsl:when>
             <xsl:otherwise>
                 <div class="alert alert-danger">No results found.</div>
-            </xsl:otherwise>                    
+            </xsl:otherwise>
         </xsl:choose>
     </xsl:template>
 
@@ -61,7 +61,7 @@ $report['xsl'] =<<<'EOD'
                         <xsl:when test="@use_photo = '1'">
                             <xsl:text>Yes</xsl:text>
                         </xsl:when>
-                        <xsl:when test="@use_photo = '0'">
+                        <xsl:when test="@use_photo = '2'">
                             <xsl:text>No</xsl:text>
                         </xsl:when>
                         <xsl:otherwise>

--- a/webpages/reports/oktophoto1.php
+++ b/webpages/reports/oktophoto1.php
@@ -27,7 +27,7 @@ SELECT
                         JOIN Participants P2 USING (badgeid)
                     WHERE
                         S2.sessionid = S.sessionid
-                        AND IFNULL(P2.use_photo, 0) = 0
+                        AND IFNULL(P2.use_photo, 0) IN (0, 2)
                 );
 EOD;
 $report['queries']['participants'] =<<<'EOD'
@@ -50,7 +50,7 @@ SELECT
                         JOIN Participants P2 USING (badgeid)
                     WHERE
                         S2.sessionid = S.sessionid
-                        AND IFNULL(P2.use_photo, 0) = 0
+                        AND IFNULL(P2.use_photo, 0) IN (0, 2)
                 )
     ORDER BY
         IF(INSTR(P.pubsname, CD.lastname) > 0, CD.lastname, SUBSTRING_INDEX(P.pubsname, ' ', -1)),

--- a/webpages/reports/oktophoto2.php
+++ b/webpages/reports/oktophoto2.php
@@ -21,7 +21,7 @@ SELECT
              Sessions S
         JOIN Schedule SCH USING (sessionid)
         JOIN Rooms R USING (roomid)
-        JOIN Tracks TR USING (trackid) 
+        JOIN Tracks TR USING (trackid)
     WHERE EXISTS (
         SELECT *
             FROM
@@ -191,7 +191,7 @@ $report['xsl'] =<<<'EOD'
     <xsl:template name="oktophoto">
         <xsl:param name="use_photo" />
         <xsl:choose>
-            <xsl:when test="$use_photo='0'">
+            <xsl:when test="$use_photo='2'">
                 <xsl:text>No</xsl:text>
             </xsl:when>
             <xsl:when test="$use_photo='1'">

--- a/webpages/reports/sessioninterest.php
+++ b/webpages/reports/sessioninterest.php
@@ -16,6 +16,8 @@ SELECT
         S.title,
         P.pubsname,
         P.badgeid,
+        P.allow_streaming,
+        P.allow_recording,
         PSI.rank,
         PSI.willmoderate,
         PSI.attend_type,
@@ -56,6 +58,8 @@ $report['xsl'] =<<<'EOD'
                             <th>Rank</th>
                             <th>Will Mod</th>
                             <th>How Attend</th>
+                            <th>Allow Streaming</th>
+                            <th>Allow Recording</th>
                             <th>Comments</th>
                         </tr>
                     </thead>
@@ -114,6 +118,20 @@ $report['xsl'] =<<<'EOD'
                     </xsl:when>
                     <xsl:otherwise>
                     </xsl:otherwise>
+                </xsl:choose>
+            </td>
+            <td class="report">
+                <xsl:choose>
+                    <xsl:when test="@allow_streaming='1'">Yes</xsl:when>
+                    <xsl:when test="@allow_streaming='2'">No</xsl:when>
+                    <xsl:otherwise>Didn't respond</xsl:otherwise>
+                </xsl:choose>
+            </td>
+            <td class="report">
+                <xsl:choose>
+                    <xsl:when test="@allow_recording='1'">Yes</xsl:when>
+                    <xsl:when test="@allow_recording='2'">No</xsl:when>
+                    <xsl:otherwise>Didn't respond</xsl:otherwise>
                 </xsl:choose>
             </td>
             <td><xsl:value-of select="@comments" /></td>

--- a/webpages/xsl/AdminParticipants.xsl
+++ b/webpages/xsl/AdminParticipants.xsl
@@ -32,6 +32,18 @@
                           <input type="hidden" id="interestedHID_{@badgeid}">
                               <xsl:attribute name="value"><xsl:value-of select="@interested"/></xsl:attribute>
                           </input>
+                          <input type="hidden" id="shareEmailHID_{@badgeid}">
+                              <xsl:attribute name="value"><xsl:value-of select="@share_email"/></xsl:attribute>
+                          </input>
+                          <input type="hidden" id="usePhotoHID_{@badgeid}">
+                              <xsl:attribute name="value"><xsl:value-of select="@use_photo"/></xsl:attribute>
+                          </input>
+                          <input type="hidden" id="allowStreamingHID_{@badgeid}">
+                              <xsl:attribute name="value"><xsl:value-of select="@allow_streaming"/></xsl:attribute>
+                          </input>
+                          <input type="hidden" id="allowRecordingHID_{@badgeid}">
+                              <xsl:attribute name="value"><xsl:value-of select="@allow_recording"/></xsl:attribute>
+                          </input>
                           <input type="hidden" id="spnameHID_{@badgeid}">
                             <xsl:attribute name="value">
                               <xsl:value-of select="@sortedpubsname"/>

--- a/webpages/xsl/PartSearchSessions.xsl
+++ b/webpages/xsl/PartSearchSessions.xsl
@@ -9,17 +9,42 @@
     <xsl:param name="conName" />
     <xsl:param name="showTags" />
     <xsl:param name="showTrack" />
-    <xsl:variable name="interested" select="/doc/query[@queryName='interested']/row/@interested = '1'"/>
+    <xsl:param name="ENABLE_SHARE_EMAIL_QUESTION" />
+    <xsl:param name="ENABLE_USE_PHOTO_QUESTION" />
+    <xsl:param name="ENABLE_ALLOW_STREAMING_QUESTION" />
+    <xsl:param name="ENABLE_ALLOW_RECORDING_QUESTION" />
+    <xsl:variable name="interested" select="/doc/query[@queryName='participant']/row/@interested = '1'"/>
+    <xsl:variable name="share_email" select="/doc/query[@queryName='participant']/row/@share_email"/>
+    <xsl:variable name="use_photo" select="/doc/query[@queryName='participant']/row/@use_photo"/>
+    <xsl:variable name="allow_streaming" select="/doc/query[@queryName='participant']/row/@allow_streaming"/>
+    <xsl:variable name="allow_recording" select="/doc/query[@queryName='participant']/row/@allow_recording"/>
+    <xsl:variable name="permissions_complete"
+                select="($share_email = 1 or $share_email = 2 or $ENABLE_SHARE_EMAIL_QUESTION) and
+                        ($use_photo = 1 or $use_photo = 2 or $ENABLE_USE_PHOTO_QUESTION) and
+                        ($allow_streaming = 1 or $allow_streaming = 2 or $ENABLE_ALLOW_STREAMING_QUESTION) and
+                        ($allow_recording = 1 or $allow_recording = 2 or $ENABLE_ALLOW_RECORDING_QUESTION)"/>
 
     <xsl:template match="/">
         <div class="container-fluid">
             <xsl:if test="not($interested)">
                 <div class="row">
-                    <div class="alert alert-block" style="margin:15px 0;">
+                    <div class="col-auto offset-sm-2 alert alert-danger">
                         <h4>Warning!</h4>
                         <span>
                             You have not indicated in your profile that you will be attending <xsl:value-of select="$conName"/>.
                             You will not be able to save your panel choices until you so do.
+                        </span>
+                    </div>
+                </div>
+            </xsl:if>
+            <xsl:if test="not($permissions_complete)">
+                <div class="row">
+                    <div class="col-auto offset-sm-2 alert alert-danger">
+                        <h4>Warning!</h4>
+                        <span>
+                            You have not answered all of the permissions questions in your profile.
+                            You will not be able to save your panel choices
+                            until you so do.
                         </span>
                     </div>
                 </div>
@@ -94,7 +119,7 @@
                 <xsl:value-of select="@tagname" />
             </label>
         </div>
-        
+
     </xsl:template>
 
 </xsl:stylesheet>

--- a/webpages/xsl/PartSearchSessionsSubmit.xsl
+++ b/webpages/xsl/PartSearchSessionsSubmit.xsl
@@ -12,8 +12,22 @@
     <xsl:param name="showTrack" />
     <xsl:param name="showTags" />
     <xsl:param name="collapse_list" />
-    <xsl:variable name="interested" select="/doc/query[@queryName='interested']/row/@interested='1'"/>
-    <xsl:variable name="mayISubmitPanelInterests" select="$interested and $may_I" />
+    <xsl:param name="ENABLE_SHARE_EMAIL_QUESTION" />
+    <xsl:param name="ENABLE_USE_PHOTO_QUESTION" />
+    <xsl:param name="ENABLE_ALLOW_STREAMING_QUESTION" />
+    <xsl:param name="ENABLE_ALLOW_RECORDING_QUESTION" />
+    <xsl:variable name="interested" select="/doc/query[@queryName='participant']/row/@interested = '1'"/>
+    <xsl:variable name="share_email" select="/doc/query[@queryName='participant']/row/@share_email"/>
+    <xsl:variable name="use_photo" select="/doc/query[@queryName='participant']/row/@use_photo"/>
+    <xsl:variable name="allow_streaming" select="/doc/query[@queryName='participant']/row/@allow_streaming"/>
+    <xsl:variable name="allow_recording" select="/doc/query[@queryName='participant']/row/@allow_recording"/>
+    <xsl:variable name="permissions_complete"
+                select="($share_email = 1 or $share_email = 2 or $ENABLE_SHARE_EMAIL_QUESTION) and
+                        ($use_photo = 1 or $use_photo = 2 or $ENABLE_USE_PHOTO_QUESTION) and
+                        ($allow_streaming = 1 or $allow_streaming = 2 or $ENABLE_ALLOW_STREAMING_QUESTION) and
+                        ($allow_recording = 1 or $allow_recording = 2 or $ENABLE_ALLOW_RECORDING_QUESTION)"/>
+    <xsl:variable name="mayISubmitPanelInterests"
+                select="$interested and $permissions_complete and $may_I" />
 
     <xsl:template match="/">
         <div class="row-fluid">
@@ -23,6 +37,17 @@
                     <h4>Warning!</h4>
                     <span>
                         You have not indicated in your profile that you will be attending <xsl:value-of select="$conName"/>.
+                        You will not be able to save your panel choices until you so do.
+                    </span>
+                </div>
+            </div>
+        </xsl:if>
+        <xsl:if test="not($permissions_complete)">
+            <div class="row">
+                <div class="col-auto offset-sm-2 alert alert-danger">
+                    <h4>Warning!</h4>
+                    <span>
+                        You have not answered all of the permissions questions in your profile.
                         You will not be able to save your panel choices until you so do.
                     </span>
                 </div>

--- a/webpages/xsl/my_profile.xsl
+++ b/webpages/xsl/my_profile.xsl
@@ -20,6 +20,8 @@
     <xsl:output encoding="UTF-8" indent="yes" method="xml" />
     <xsl:template match="/">
         <xsl:variable name="use_photo" select="/doc/query[@queryName='participant_info']/row/@use_photo" />
+        <xsl:variable name="allow_streaming" select="/doc/query[@queryName='participant_info']/row/@allow_streaming" />
+        <xsl:variable name="allow_recording" select="/doc/query[@queryName='participant_info']/row/@allow_recording" />
         <xsl:variable name="share_email" select="/doc/query[@queryName='participant_info']/row/@share_email" />
         <xsl:variable name="interested" select="/doc/query[@queryName='participant_info']/row/@interested" />
         <xsl:variable name="bestway" select="/doc/query[@queryName='participant_info']/row/@bestway" />
@@ -98,14 +100,15 @@
                                     </div>
                                     <div class="col-auto">
                                         <select id="share_email" name="share_email" class="mb-2 pl-2 pr-4 mycontrol">
-                                            <option value="null">
-                                                <xsl:if test="not($share_email) and $share_email !='0'"><!-- is there an explicit test for null? -->
+                                            <option value="0">
+                                                <xsl:if
+                                                test="not($share_email)"><!-- select for null or zero -->
                                                     <xsl:attribute name="selected">selected</xsl:attribute>
                                                 </xsl:if>
                                                 <xsl:text disable-output-escaping="yes">&amp;nbsp;</xsl:text>
                                             </option>
-                                            <option value="0">
-                                                <xsl:if test="$share_email = '0'">
+                                            <option value="2">
+                                                <xsl:if test="$share_email = '2'">
                                                     <xsl:attribute name="selected">selected</xsl:attribute>
                                                 </xsl:if>
                                                 No
@@ -132,19 +135,19 @@
                                     <div class="col-auto">
                                         <label for="use_photo">
                                             I give permission for <xsl:value-of select="$conName"/> to photograph me while
-                                            I am on panels and to use those images in the promotion of the convention:
+                                            I am on panels and to use those images in<!-- is there an explicit test for null? --> the promotion of the convention:
                                         </label>
                                     </div>
                                     <div class="col-auto">
                                         <select id="use_photo" name="use_photo" class="mb-2 pl-2 pr-4 mycontrol">
-                                            <option value="null">
-                                                <xsl:if test="not($use_photo) and $use_photo != '0'"><!-- is there an explicit test for null? -->
+                                            <option value="0">
+                                                <xsl:if test="not($use_photo)">
                                                     <xsl:attribute name="selected">selected</xsl:attribute>
                                                 </xsl:if>
                                                 <xsl:text disable-output-escaping="yes">&amp;nbsp;</xsl:text>
                                             </option>
-                                            <option value="0">
-                                                <xsl:if test="$use_photo = '0'">
+                                            <option value="2">
+                                                <xsl:if test="$use_photo = '2'">
                                                     <xsl:attribute name="selected">selected</xsl:attribute>
                                                 </xsl:if>
                                                 No
@@ -162,6 +165,84 @@
                         </xsl:when>
                         <xsl:otherwise>
                             <input name="use_photo" type="hidden" value="{$use_photo}"/>
+                        </xsl:otherwise>
+                    </xsl:choose>
+                    <xsl:choose>
+                        <xsl:when test="$enableStreamingQuestion = '1'">
+                            <fieldset>
+                                <div class="row">
+                                    <div class="col-auto">
+                                        <label for="allow_streaming">
+                                            I give permission for <xsl:value-of select="$conName"/>
+                                            to live stream sessions I participate in:
+                                        </label>
+                                    </div>
+                                    <div class="col-auto">
+                                        <select id="allow_streaming" name="allow_streaming" class="mb-2 pl-2 pr-4 mycontrol">
+                                            <option value="null">
+                                                <xsl:if test="not($allow_streaming)">
+                                                    <xsl:attribute name="selected">selected</xsl:attribute>
+                                                </xsl:if>
+                                                <xsl:text disable-output-escaping="yes">&amp;nbsp;</xsl:text>
+                                            </option>
+                                            <option value="2">
+                                                <xsl:if test="$allow_streaming = '2'">
+                                                    <xsl:attribute name="selected">selected</xsl:attribute>
+                                                </xsl:if>
+                                                No
+                                            </option>
+                                            <option value="1">
+                                                <xsl:if test="$allow_streaming = '1'">
+                                                    <xsl:attribute name="selected">selected</xsl:attribute>
+                                                </xsl:if>
+                                                Yes
+                                            </option>
+                                        </select>
+                                    </div>
+                                </div>
+                            </fieldset>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <input name="allow_streaming" type="hidden" value="{$allow_streaming}"/>
+                        </xsl:otherwise>
+                    </xsl:choose>
+                    <xsl:choose>
+                        <xsl:when test="$enableRecordingQuestion = '1'">
+                            <fieldset>
+                                <div class="row">
+                                    <div class="col-auto">
+                                        <label for="allow_recording">
+                                            I give permission for <xsl:value-of select="$conName"/>
+                                            to record sessions I participate in and make available for catchup:
+                                        </label>
+                                    </div>
+                                    <div class="col-auto">
+                                        <select id="allow_recording" name="allow_recording" class="mb-2 pl-2 pr-4 mycontrol">
+                                            <option value="null">
+                                                <xsl:if test="not($allow_recording)">
+                                                    <xsl:attribute name="selected">selected</xsl:attribute>
+                                                </xsl:if>
+                                                <xsl:text disable-output-escaping="yes">&amp;nbsp;</xsl:text>
+                                            </option>
+                                            <option value="2">
+                                                <xsl:if test="$allow_recording = '2'">
+                                                    <xsl:attribute name="selected">selected</xsl:attribute>
+                                                </xsl:if>
+                                                No
+                                            </option>
+                                            <option value="1">
+                                                <xsl:if test="$allow_recording = '1'">
+                                                    <xsl:attribute name="selected">selected</xsl:attribute>
+                                                </xsl:if>
+                                                Yes
+                                            </option>
+                                        </select>
+                                    </div>
+                                </div>
+                            </fieldset>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <input name="allow_recording" type="hidden" value="{$allow_recording}"/>
                         </xsl:otherwise>
                     </xsl:choose>
                     <xsl:choose>


### PR DESCRIPTION
This change adds "Live Stream" and "Record" permission questions to the "My Profile" page.

## Database changes

Two new fields added to `Permissions` table:
- `allow_streaming`
- `allow_recording`

Also updates the `Permissions` table to set `share_email` and `use_photo` to 2 where they were 0. This is to for **Make permission storage consistent** below.

It also adds a new `PermissionAtom` entry to for **EditUserPermissions** to allow staff to edit permissions. See the _Add new questions to Admin Participant page_ section below.

## Make permission storage consistent

Before this change, **Interested** was stored as follows:
- Null or 0: Not answered
- 1: Yes
- 2: No

However, the **Share Email** and **Use Photo** permission were stored as:
- Null: Not answered
- 1: Yes
- 0: No

This inconsistency can be confusing, and also the XSL form logic can make it difficult to distinguish between 0 and Null.

This change aims to fix this inconsistency by storing all of the permissions the same way as the Interested field. This will also apply to the two new fields.

Most places where these were checked were only checking if the field is "Yes", so didn't need to change as Yes is still "1". However, some reports such as the two "OK to Photo" reports and the  Configurable Report Sample.

## Add new configuration settings

Two new settings are added to `db_name_sample.php`:
- ENABLE_ALLOW_STREAMING_QUESTION
- ENABLE_ALLOW_RECORDING_QUESTION

These default to true. If set to false, the new questions will not be shown.

## Add new questions to My Profile

The new questions are displayed below the existing permission questions.

## Add new questions to Admin Participant page

This allows them to be set for invited guests, who the admins don't want to ask to fill out questionnaires.

A new `EditUserPermissions` permission determines which roles can edit the permission questions. By default it is granted to Admin and Senior Staff roles.

## Deny Session Interests until Permissions answered

Previously participants could not save session interests if they had not answered Yes to the **Interested** question.

This change will also require users to have answered the remaining Permissions questions. If they have not answered all of the questions, the "Interested" checkbox will be greyed out, and users will be asked to return to their profile and answer the questions.

The questions may be answered Yes or No, apart from the Interested question, which must be answered Yes.

If a question is disabled in the configuration, it cannot be answered, and will not block Session Interests.

## Add to reports

So far the Streaming and Recording questions have been added to the Attending and Session Interest reports.

## To Do

1. I expect the new fields will need to be added to additional reports, once identified.
2. Look at adding to the grid scheduler, since programme planners are likely to want to know whether all participants have given permission to stream. This will help to assign items that don't have permissions for streaming/recording to rooms that don't have that technology.

These tasks may get added to this PR if ready in time, or could be follow-up PRs if appropriate.

These changes will allow #169 to be resolved.