### PR TITLE
Grid scheduler not finding any sessions

### DIFF
--- a/webpages/staffMaintainScheduleSubmit.php
+++ b/webpages/staffMaintainScheduleSubmit.php
@@ -773,16 +773,16 @@ SELECT
             SELECT * FROM Schedule SCH WHERE S.sessionid = SCH.sessionid
         )
 EOD;
-    if ($trackId !== false) {
+    if ($trackId !== false && $trackId !== 0) {
         $query["sessions"] .= " AND S.trackid = $trackId";
     }
-    if ($typeId !== false) {
+    if ($typeId !== false && $typeId !== 0) {
         $query["sessions"] .= " AND S.typeid = $typeId";
     }
-    if ($divisionId !== false) {
+    if ($divisionId !== false && $divisionId !== 0) {
         $query["sessions"] .= " AND S.divisionid = $divisionId";
     }
-    if ($sessionId !== false) {
+    if ($sessionId !== false && $sessionId !== 0) {
         $query["sessions"] .= " AND S.sessionid = $sessionId";
     }
     if ($title !== "") {


### PR DESCRIPTION
Testing in PHP 8.1, I'm not getting any results when searching for sessions in the Grid Scheduler.

When debugging the results of the form, dropdowns were coming in as 0 instead of false, causing it to add `where` conditions that would never be met.

I think this is due to my previous change to allow `getInt` to treat a zero string as an integer. I still think that change is correct, since it treats other numbers in a string as an integer, but I will need to review everywhere `getInt` is called and check for unexpected side effects.

My fix for this is to add `!== 0` to the checks. An alternative approach would be to change the checks to `!empty()`, which would match both false and zero.
