### PR TITLE
Update some reports for streaming/recording.

### DIFF
--- a/webpages/reports/sessioninterestincunranked.php
+++ b/webpages/reports/sessioninterestincunranked.php
@@ -1,7 +1,7 @@
 <?php
 // Copyright (c) 2018 Peter Olszowka. All rights reserved. See copyright document for more details.
 $report = [];
-$report['name'] = 'Session Interest Report (all info, exclude unranked)';
+$report['name'] = 'Session Interest Report (all info, include unranked)';
 $report['multi'] = 'true';
 $report['output_filename'] = 'session_interests.csv';
 $report['description'] = 'Shows who has expressed interest in each session, how they ranked it, what they said, if they will moderate... Large Report. (All data included including for invited sessions.)';
@@ -32,9 +32,7 @@ SELECT
         JOIN Participants P USING (badgeid)
         JOIN CongoDump CD USING(badgeid)
     WHERE
-            P.interested = 1
-        AND ((PSI.rank is not NULL
-            AND PSI.rank != 0) OR PSI.willmoderate = 1)
+        P.interested = 1
         AND S.statusid IN (2, 3, 7) ## Vetted, Scheduled, Assigned
     ORDER BY
         T.trackname, S.title;

--- a/webpages/reports/sessioninterestpart.php
+++ b/webpages/reports/sessioninterestpart.php
@@ -16,11 +16,14 @@ SELECT
         T.trackname,
         S.sessionid,
         S.title,
+        P.allow_streaming,
+        P.allow_recording,
         DATE_FORMAT(ADDTIME('$ConStartDatim$',SCH.starttime),'%a %l:%i %p') AS starttime,
         DATE_FORMAT(S.duration,'%i') AS durationmin,
         DATE_FORMAT(S.duration,'%k') AS durationhrs,
         PSI.rank,
         PSI.willmoderate,
+        PSI.attend_type,
         PSI.comments
     FROM
                   Participants P
@@ -59,7 +62,10 @@ $report['xsl'] =<<<'EOD'
                     <col style="width:5%" />
                     <col style="width:5%" />
                     <col style="width:5%" />
-                    <col style="width:50%" />
+                    <col style="width:5%" />
+                    <col style="width:5%" />
+                    <col style="width:5%" />
+                    <col style="width:35%" />
                     <thead>
                         <tr>
                             <th>Person ID</th>
@@ -71,6 +77,9 @@ $report['xsl'] =<<<'EOD'
                             <th>Duration</th>
                             <th>Rank</th>
                             <th>Moderator</th>
+                            <th>How Attend</th>
+                            <th>Allow Streaming</th>
+                            <th>Allow Recording</th>
                             <th>Comments</th>
                         </tr>
                     </thead>
@@ -120,6 +129,35 @@ $report['xsl'] =<<<'EOD'
             <td><xsl:value-of select="@rank" /></td>
             <td>
                 <xsl:if test="@willmoderate='1'">Yes</xsl:if>
+            </td>
+            <td>
+                <xsl:choose>
+                    <xsl:when test="@attend_type = '1'">
+                        In Person
+                    </xsl:when>
+                    <xsl:when test="@attend_type = '2'">
+                        Online
+                    </xsl:when>
+                    <xsl:when test="@attend_type = '3'">
+                        Either
+                    </xsl:when>
+                    <xsl:otherwise>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </td>
+            <td class="report">
+                <xsl:choose>
+                    <xsl:when test="@allow_streaming='1'">Yes</xsl:when>
+                    <xsl:when test="@allow_streaming='2'">No</xsl:when>
+                    <xsl:otherwise>Didn't respond</xsl:otherwise>
+                </xsl:choose>
+            </td>
+            <td class="report">
+                <xsl:choose>
+                    <xsl:when test="@allow_recording='1'">Yes</xsl:when>
+                    <xsl:when test="@allow_recording='2'">No</xsl:when>
+                    <xsl:otherwise>Didn't respond</xsl:otherwise>
+                </xsl:choose>
             </td>
             <td><xsl:value-of select="@comments" /></td>
         </tr>


### PR DESCRIPTION
This change contains changes to 2 existing reports, and the addition of a new report.

"Session Interest Report (all info)" has just changed its label to "Session Interest Report (all info, exclude unranked)". There are some minor formatting changes to fix indentation as the file previously had a mix of spaces and tabs. The label change is to distinguish from the new report.

"Session Interest Report (all info, include unranked)" is cloned from the above report. The only difference is that participants who have selected programme items but not ranked them are included.

"Session Interest by participant (all info)" has been modified to add the "Attending how", "Allow Streaming", and "Allow Recording" columns.

This includes changes for #169.