### PR TITLE
Change to Badge Stickers report

### DIFF
--- a/webpages/js/ReportBadgeStickers.js
+++ b/webpages/js/ReportBadgeStickers.js
@@ -26,8 +26,12 @@ window.onload = function() {
   document.getElementById("fontsize").oninput = resizeStickers;
   document.getElementById("badgenumbers").oninput = filterBadges;
   document.getElementById("skip").oninput = insertBlankLabels;
+  document.getElementById("showname").oninput = showName;
+  document.getElementById("showbadgeid").oninput = showBadgeID;
   document.getElementById("borders").oninput = showBorders;
   resizeStickers();
+  showName();
+  showBadgeID();
 }
 
 // Set label size and spacing.
@@ -62,7 +66,7 @@ function resizeStickers() {
   localStorage.setItem("fontsize", fontsize);
 }
 
-// Apply filtering to badges if specified in 
+// Apply filtering to badges if specified in
 function filterBadges() {
   // Get the badge numbers field.
   var badgenumbers = document.getElementById("badgenumbers").value;
@@ -103,6 +107,24 @@ function filterBadges() {
       element.style.display = "inline-block";
     });
   }
+}
+
+// Show or hide badge ID depending on checkbox.
+function showBadgeID() {
+  const showBadgeID = document.getElementById("showbadgeid").checked;
+  const display = showBadgeID ? 'inline' : 'none';
+  Array.from(document.getElementsByClassName('badge-sticker-badgeid')).forEach((element) => element.style.display = display);
+}
+
+// Show or hide names based on drop-down.
+function showName() {
+  const showName = document.getElementById("showname").value;
+  const displayPubs = showName === 'pubsname' ? 'inline' : 'none';
+  const displaySort = showName === 'sortname' ? 'inline' : 'none';
+  const displayBadge = showName === 'badgename' ? 'inline' : 'none';
+  Array.from(document.getElementsByClassName('badge-sticker-pubsname')).forEach((element) => element.style.display = displayPubs);
+  Array.from(document.getElementsByClassName('badge-sticker-sortedname')).forEach((element) => element.style.display = displaySort);
+  Array.from(document.getElementsByClassName('badge-sticker-badgename')).forEach((element) => element.style.display = displayBadge);
 }
 
 // Check if borders checkbox checked and apply borders to labels if required.

--- a/webpages/reports/ProgramScheduleBadgeStickers.php
+++ b/webpages/reports/ProgramScheduleBadgeStickers.php
@@ -9,7 +9,10 @@ $report['categories'] = array(
 $report['queries'] = [];
 $report['queries']['participants'] =<<<'EOD'
 SELECT
-        P.badgeid, P.pubsname
+        P.badgeid,
+        P.pubsname,
+        P.sortedpubsname,
+        CD.badgename
     FROM
              Participants P
         JOIN CongoDump CD USING (badgeid)
@@ -94,6 +97,18 @@ $report['xsl'] =<<<'EOD'
                         <input type="number" name="skip" id="skip" value="0" min="0" max="30" step="1"></input>
                     </div>
                     <div class="form-element">
+                        <label for="showname">Show Name</label>
+                        <select name="showname" id="showname">
+                            <option value="pubsname">Publichation name</option>
+                            <option value="sortname">Sorted name</option>
+                            <option value="badgename">Badge name</option>
+                        </select>
+                    </div>
+                    <div class="form-element">
+                        <label for="showbadgeid">Show badge ID</label>
+                        <input type="checkbox" name="showbadgeid" id="showbadgeid"></input>
+                    </div>
+                    <div class="form-element">
                         <label for="borders">Show label borders</label>
                         <input type="checkbox" name="borders" id="borders"></input>
                     </div>
@@ -113,9 +128,10 @@ $report['xsl'] =<<<'EOD'
         <xsl:variable name="badgeid" select="@badgeid" />
         <div class="badge-sticker" id="{@badgeid}">
             <div class="participant">
-                <span><xsl:value-of select="@badgeid" /></span>
-                <xsl:text> </xsl:text>
-                <span><xsl:value-of select="@pubsname" /></span>
+                <span class="badge-sticker-badgeid"><xsl:value-of select="@badgeid" /><xsl:text> </xsl:text></span>
+                <span class="badge-sticker-pubsname"><xsl:value-of select="@pubsname" /><xsl:text> </xsl:text></span>
+                <span class="badge-sticker-sortedname"><xsl:value-of select="@sortedpubsname" /><xsl:text> </xsl:text></span>
+                <span class="badge-sticker-badgename"><xsl:value-of select="@badgename" /><xsl:text> </xsl:text></span>
             </div>
             <div>
                 <xsl:apply-templates select="/doc/query[@queryName='sessions']/row[@badgeid=$badgeid]" />


### PR DESCRIPTION
For Eastercon 2025, the badge ID does not relate to the member number from the registration system, so we don't want to show it on the badge stickers.

We also wanted to put badge name rather than publication name on the badge sticker.

This adds a new dropdown and checkbox to the report:

- Show Name selects which name is shown, and contains "Publication Name", "Sorted Name", and "Badge Name".
- Show Badge ID is a checkbox and if checked, the badge ID is shown before the name. If unchecked, only the name is shown.

In practice, all three names are displayed on the report, and the parts that aren't needed are hidden with JavaScript.