### PR TITLE
Date parsing bug

### DIFF
--- a/webpages/api/format_functions.php
+++ b/webpages/api/format_functions.php
@@ -23,10 +23,11 @@ function convert_database_date_no_time_to_date($db_date) {
 function convert_iso_date_to_date($date) {
     if ($date) {
         if (substr($date, -1) === 'Z') {
-            return date_create_from_format('Y-m-d\TH:i:s.v\Z', $date);
-        } else {
-            return date_create_from_format(DateTime::ISO8601, $date);
+            $date = substr($date, 0, -1) . '+00:00';
         }
+        $result = date_create_from_format("Y-m-d\\TH:i:s.vP", $date);
+        $result->setTimezone(new DateTimeZone(PHP_DEFAULT_TIMEZONE));
+        return $result;
     } else {
         return null;
     }


### PR DESCRIPTION
When the JSON date uses 'Z' for the timezone, the wrong date gets persisted to the database