### PR TITLE
Allow database creation with only create permissions

### DIFF
--- a/Install/DemoDbase.dump
+++ b/Install/DemoDbase.dump
@@ -870,7 +870,7 @@ UNLOCK TABLES;
 /*!50003 SET @saved_sql_mode       = @@sql_mode */ ;
 /*!50003 SET sql_mode              = 'NO_AUTO_VALUE_ON_ZERO' */ ;
 DELIMITER ;;
-/*!50003 CREATE*/ /*!50017 DEFINER=`root`@`localhost`*/ /*!50003 TRIGGER POS_insert_trig AFTER INSERT ON ParticipantOnSession FOR EACH ROW
+/*!50003 CREATE TRIGGER POS_insert_trig AFTER INSERT ON ParticipantOnSession FOR EACH ROW
     IF (
         SELECT count(*) FROM ParticipantOnSession
             WHERE sessionid = NEW.sessionid AND moderator = 1)
@@ -3741,7 +3741,7 @@ UNLOCK TABLES;
 /*!50001 SET character_set_results     = utf8mb4 */;
 /*!50001 SET collation_connection      = utf8mb4_unicode_ci */;
 /*!50001 CREATE ALGORITHM=UNDEFINED */
-/*!50013 DEFINER=`db`@`%` SQL SECURITY DEFINER */
+/*!50013 SQL SECURITY DEFINER */
 /*!50001 VIEW `ParticipantPronouns` AS select `pd`.`badgeid` AS `badgeid`,case when `pd`.`pronounid` = 99 then `pd`.`pronounother` else `pr`.`pronounname` end AS `pronouns` from (`ParticipantDetails` `pd` join `Pronouns` `pr` on(`pd`.`pronounid` = `pr`.`pronounid`)) */;
 /*!50001 SET character_set_client      = @saved_cs_client */;
 /*!50001 SET character_set_results     = @saved_cs_results */;
@@ -3759,7 +3759,7 @@ UNLOCK TABLES;
 /*!50001 SET character_set_results     = utf8mb4 */;
 /*!50001 SET collation_connection      = utf8mb4_unicode_ci */;
 /*!50001 CREATE ALGORITHM=UNDEFINED */
-/*!50013 DEFINER=`db`@`%` SQL SECURITY DEFINER */
+/*!50013 SQL SECURITY DEFINER */
 /*!50001 VIEW `PreviousCons` AS select `con_info`.`id` AS `previousconid`,`con_info`.`name` AS `previousconname`,`con_info`.`display_order` AS `display_order` from `con_info` where `con_info`.`active_to_time` < current_timestamp() */;
 /*!50001 SET character_set_client      = @saved_cs_client */;
 /*!50001 SET character_set_results     = @saved_cs_results */;
@@ -3777,7 +3777,7 @@ UNLOCK TABLES;
 /*!50001 SET character_set_results     = utf8mb4 */;
 /*!50001 SET collation_connection      = utf8mb4_unicode_ci */;
 /*!50001 CREATE ALGORITHM=UNDEFINED */
-/*!50013 DEFINER=`db`@`%` SQL SECURITY DEFINER */
+/*!50013 SQL SECURITY DEFINER */
 /*!50001 VIEW `current_con` AS select `c`.`id` AS `id`,`c`.`name` AS `name`,`p`.`name` AS `perennial_name`,`c`.`con_start_date` AS `con_start_date`,`c`.`con_end_date` AS `con_end_date`,`p`.`website_url` AS `website_url` from (`con_info` `c` join `perennial_con_info` `p`) where `c`.`perennial_con_id` = `p`.`id` and `c`.`active_to_time` > current_timestamp() and `c`.`active_from_time` <= current_timestamp() */;
 /*!50001 SET character_set_client      = @saved_cs_client */;
 /*!50001 SET character_set_results     = @saved_cs_results */;
@@ -3795,7 +3795,7 @@ UNLOCK TABLES;
 /*!50001 SET character_set_results     = utf8mb4 */;
 /*!50001 SET collation_connection      = utf8mb4_unicode_ci */;
 /*!50001 CREATE ALGORITHM=UNDEFINED */
-/*!50013 DEFINER=`db`@`%` SQL SECURITY DEFINER */
+/*!50013 SQL SECURITY DEFINER */
 /*!50001 VIEW `session_change_history` AS (select `SEH`.`sessionid` AS `sessionid`,`SEH`.`badgeid` AS `change_by_badgeid`,concat(`CD`.`firstname`,' ',`CD`.`lastname`) AS `change_by_name`,concat(`SEC`.`description`,case when `SEH`.`editdescription` is not null then concat(' — ',`SEH`.`editdescription`) else '' end,' — status: ',`SS`.`statusname`) AS `description`,`SEH`.`timestamp` AS `change_ts` from (((`SessionEditHistory` `SEH` join `SessionEditCodes` `SEC` on(`SEH`.`sessioneditcode` = `SEC`.`sessioneditcode`)) join `SessionStatuses` `SS` on(`SEH`.`statusid` = `SS`.`statusid`)) join `CongoDump` `CD` on(`CD`.`badgeid` = `SEH`.`badgeid`))) union (select `POSH`.`sessionid` AS `sessionid`,`POSH`.`change_by_badgeid` AS `change_by_badgeid`,`PartCR`.`pubsname` AS `change_by_name`,case when `POSH`.`change_type` = 'insert_assignment' then concat('Add ',`PartOS`.`pubsname`,' to session') when `POSH`.`change_type` = 'remove_assignment' then concat('Remove ',`PartOS`.`pubsname`,' from session') when `POSH`.`change_type` = 'assign_moderator' then concat('Assign ',`PartOS`.`pubsname`,' as moderator') when `POSH`.`change_type` = 'remove_moderator' then concat('Unassign ',`PartOS`.`pubsname`,' as moderator') else 'Unknown action.' end AS `description`,`POSH`.`change_ts` AS `change_ts` from ((`participant_on_session_history` `POSH` join `Participants` `PartOS` on(`PartOS`.`badgeid` = `POSH`.`badgeid`)) join `Participants` `PartCR` on(`PartCR`.`badgeid` = `POSH`.`change_by_badgeid`))) */;
 /*!50001 SET character_set_client      = @saved_cs_client */;
 /*!50001 SET character_set_results     = @saved_cs_results */;

--- a/Install/EmptyDbase.dump
+++ b/Install/EmptyDbase.dump
@@ -1,4 +1,4 @@
-/*M!999999\- enable the sandbox mode */ 
+/*M!999999\- enable the sandbox mode */
 -- MariaDB dump 10.19  Distrib 10.11.10-MariaDB, for debian-linux-gnu (x86_64)
 --
 -- Host: db    Database: db
@@ -825,7 +825,7 @@ UNLOCK TABLES;
 /*!50003 SET @saved_sql_mode       = @@sql_mode */ ;
 /*!50003 SET sql_mode              = 'NO_AUTO_VALUE_ON_ZERO' */ ;
 DELIMITER ;;
-/*!50003 CREATE*/ /*!50017 DEFINER=`root`@`localhost`*/ /*!50003 TRIGGER POS_insert_trig AFTER INSERT ON ParticipantOnSession FOR EACH ROW
+/*!50003 CREATE TRIGGER POS_insert_trig AFTER INSERT ON ParticipantOnSession FOR EACH ROW
     IF (
         SELECT count(*) FROM ParticipantOnSession
             WHERE sessionid = NEW.sessionid AND moderator = 1)
@@ -3567,7 +3567,7 @@ UNLOCK TABLES;
 /*!50001 SET character_set_results     = utf8mb4 */;
 /*!50001 SET collation_connection      = utf8mb4_unicode_ci */;
 /*!50001 CREATE ALGORITHM=UNDEFINED */
-/*!50013 DEFINER=`db`@`%` SQL SECURITY DEFINER */
+/*!50013 SQL SECURITY DEFINER */
 /*!50001 VIEW `ParticipantPronouns` AS select `pd`.`badgeid` AS `badgeid`,case when `pd`.`pronounid` = 99 then `pd`.`pronounother` else `pr`.`pronounname` end AS `pronouns` from (`ParticipantDetails` `pd` join `Pronouns` `pr` on(`pd`.`pronounid` = `pr`.`pronounid`)) */;
 /*!50001 SET character_set_client      = @saved_cs_client */;
 /*!50001 SET character_set_results     = @saved_cs_results */;
@@ -3585,7 +3585,7 @@ UNLOCK TABLES;
 /*!50001 SET character_set_results     = utf8mb4 */;
 /*!50001 SET collation_connection      = utf8mb4_unicode_ci */;
 /*!50001 CREATE ALGORITHM=UNDEFINED */
-/*!50013 DEFINER=`db`@`%` SQL SECURITY DEFINER */
+/*!50013 SQL SECURITY DEFINER */
 /*!50001 VIEW `PreviousCons` AS select `con_info`.`id` AS `previousconid`,`con_info`.`name` AS `previousconname`,`con_info`.`display_order` AS `display_order` from `con_info` where `con_info`.`active_to_time` < current_timestamp() */;
 /*!50001 SET character_set_client      = @saved_cs_client */;
 /*!50001 SET character_set_results     = @saved_cs_results */;
@@ -3603,7 +3603,7 @@ UNLOCK TABLES;
 /*!50001 SET character_set_results     = utf8mb4 */;
 /*!50001 SET collation_connection      = utf8mb4_unicode_ci */;
 /*!50001 CREATE ALGORITHM=UNDEFINED */
-/*!50013 DEFINER=`db`@`%` SQL SECURITY DEFINER */
+/*!50013 SQL SECURITY DEFINER */
 /*!50001 VIEW `current_con` AS select `c`.`id` AS `id`,`c`.`name` AS `name`,`p`.`name` AS `perennial_name`,`c`.`con_start_date` AS `con_start_date`,`c`.`con_end_date` AS `con_end_date`,`p`.`website_url` AS `website_url` from (`con_info` `c` join `perennial_con_info` `p`) where `c`.`perennial_con_id` = `p`.`id` and `c`.`active_to_time` > current_timestamp() and `c`.`active_from_time` <= current_timestamp() */;
 /*!50001 SET character_set_client      = @saved_cs_client */;
 /*!50001 SET character_set_results     = @saved_cs_results */;
@@ -3621,7 +3621,7 @@ UNLOCK TABLES;
 /*!50001 SET character_set_results     = utf8mb4 */;
 /*!50001 SET collation_connection      = utf8mb4_unicode_ci */;
 /*!50001 CREATE ALGORITHM=UNDEFINED */
-/*!50013 DEFINER=`db`@`%` SQL SECURITY DEFINER */
+/*!50013 SQL SECURITY DEFINER */
 /*!50001 VIEW `session_change_history` AS (select `SEH`.`sessionid` AS `sessionid`,`SEH`.`badgeid` AS `change_by_badgeid`,concat(`CD`.`firstname`,' ',`CD`.`lastname`) AS `change_by_name`,concat(`SEC`.`description`,case when `SEH`.`editdescription` is not null then concat(' — ',`SEH`.`editdescription`) else '' end,' — status: ',`SS`.`statusname`) AS `description`,`SEH`.`timestamp` AS `change_ts` from (((`SessionEditHistory` `SEH` join `SessionEditCodes` `SEC` on(`SEH`.`sessioneditcode` = `SEC`.`sessioneditcode`)) join `SessionStatuses` `SS` on(`SEH`.`statusid` = `SS`.`statusid`)) join `CongoDump` `CD` on(`CD`.`badgeid` = `SEH`.`badgeid`))) union (select `POSH`.`sessionid` AS `sessionid`,`POSH`.`change_by_badgeid` AS `change_by_badgeid`,`PartCR`.`pubsname` AS `change_by_name`,case when `POSH`.`change_type` = 'insert_assignment' then concat('Add ',`PartOS`.`pubsname`,' to session') when `POSH`.`change_type` = 'remove_assignment' then concat('Remove ',`PartOS`.`pubsname`,' from session') when `POSH`.`change_type` = 'assign_moderator' then concat('Assign ',`PartOS`.`pubsname`,' as moderator') when `POSH`.`change_type` = 'remove_moderator' then concat('Unassign ',`PartOS`.`pubsname`,' as moderator') else 'Unknown action.' end AS `description`,`POSH`.`change_ts` AS `change_ts` from ((`participant_on_session_history` `POSH` join `Participants` `PartOS` on(`PartOS`.`badgeid` = `POSH`.`badgeid`)) join `Participants` `PartCR` on(`PartCR`.`badgeid` = `POSH`.`change_by_badgeid`))) */;
 /*!50001 SET character_set_client      = @saved_cs_client */;
 /*!50001 SET character_set_results     = @saved_cs_results */;

--- a/Install/SampleDbase.dump
+++ b/Install/SampleDbase.dump
@@ -859,7 +859,7 @@ UNLOCK TABLES;
 /*!50003 SET @saved_sql_mode       = @@sql_mode */ ;
 /*!50003 SET sql_mode              = 'NO_AUTO_VALUE_ON_ZERO' */ ;
 DELIMITER ;;
-/*!50003 CREATE*/ /*!50017 DEFINER=`root`@`localhost`*/ /*!50003 TRIGGER POS_insert_trig AFTER INSERT ON ParticipantOnSession FOR EACH ROW
+/*!50003 CREATE TRIGGER POS_insert_trig AFTER INSERT ON ParticipantOnSession FOR EACH ROW
     IF (
         SELECT count(*) FROM ParticipantOnSession
             WHERE sessionid = NEW.sessionid AND moderator = 1)
@@ -3704,7 +3704,7 @@ UNLOCK TABLES;
 /*!50001 SET character_set_results     = utf8mb4 */;
 /*!50001 SET collation_connection      = utf8mb4_unicode_ci */;
 /*!50001 CREATE ALGORITHM=UNDEFINED */
-/*!50013 DEFINER=`db`@`%` SQL SECURITY DEFINER */
+/*!50013 SQL SECURITY DEFINER */
 /*!50001 VIEW `ParticipantPronouns` AS select `pd`.`badgeid` AS `badgeid`,case when `pd`.`pronounid` = 99 then `pd`.`pronounother` else `pr`.`pronounname` end AS `pronouns` from (`ParticipantDetails` `pd` join `Pronouns` `pr` on(`pd`.`pronounid` = `pr`.`pronounid`)) */;
 /*!50001 SET character_set_client      = @saved_cs_client */;
 /*!50001 SET character_set_results     = @saved_cs_results */;
@@ -3722,7 +3722,7 @@ UNLOCK TABLES;
 /*!50001 SET character_set_results     = utf8mb4 */;
 /*!50001 SET collation_connection      = utf8mb4_unicode_ci */;
 /*!50001 CREATE ALGORITHM=UNDEFINED */
-/*!50013 DEFINER=`db`@`%` SQL SECURITY DEFINER */
+/*!50013 SQL SECURITY DEFINER */
 /*!50001 VIEW `PreviousCons` AS select `con_info`.`id` AS `previousconid`,`con_info`.`name` AS `previousconname`,`con_info`.`display_order` AS `display_order` from `con_info` where `con_info`.`active_to_time` < current_timestamp() */;
 /*!50001 SET character_set_client      = @saved_cs_client */;
 /*!50001 SET character_set_results     = @saved_cs_results */;
@@ -3740,7 +3740,7 @@ UNLOCK TABLES;
 /*!50001 SET character_set_results     = utf8mb4 */;
 /*!50001 SET collation_connection      = utf8mb4_unicode_ci */;
 /*!50001 CREATE ALGORITHM=UNDEFINED */
-/*!50013 DEFINER=`db`@`%` SQL SECURITY DEFINER */
+/*!50013 SQL SECURITY DEFINER */
 /*!50001 VIEW `current_con` AS select `c`.`id` AS `id`,`c`.`name` AS `name`,`p`.`name` AS `perennial_name`,`c`.`con_start_date` AS `con_start_date`,`c`.`con_end_date` AS `con_end_date`,`p`.`website_url` AS `website_url` from (`con_info` `c` join `perennial_con_info` `p`) where `c`.`perennial_con_id` = `p`.`id` and `c`.`active_to_time` > current_timestamp() and `c`.`active_from_time` <= current_timestamp() */;
 /*!50001 SET character_set_client      = @saved_cs_client */;
 /*!50001 SET character_set_results     = @saved_cs_results */;
@@ -3758,7 +3758,7 @@ UNLOCK TABLES;
 /*!50001 SET character_set_results     = utf8mb4 */;
 /*!50001 SET collation_connection      = utf8mb4_general_ci */;
 /*!50001 CREATE ALGORITHM=UNDEFINED */
-/*!50013 DEFINER=`root`@`localhost` SQL SECURITY DEFINER */
+/*!50013 SQL SECURITY DEFINER */
 /*!50001 VIEW `session_change_history` AS (select `SEH`.`sessionid` AS `sessionid`,`SEH`.`badgeid` AS `change_by_badgeid`,concat(`CD`.`firstname`,' ',`CD`.`lastname`) AS `change_by_name`,concat(`SEC`.`description`,case when `SEH`.`editdescription` is not null then concat(' — ',`SEH`.`editdescription`) else '' end,' — status: ',`SS`.`statusname`) AS `description`,`SEH`.`timestamp` AS `change_ts` from (((`SessionEditHistory` `SEH` join `SessionEditCodes` `SEC` on(`SEH`.`sessioneditcode` = `SEC`.`sessioneditcode`)) join `SessionStatuses` `SS` on(`SEH`.`statusid` = `SS`.`statusid`)) join `CongoDump` `CD` on(`CD`.`badgeid` = `SEH`.`badgeid`))) union (select `POSH`.`sessionid` AS `sessionid`,`POSH`.`change_by_badgeid` AS `change_by_badgeid`,`PartCR`.`pubsname` AS `change_by_name`,case when `POSH`.`change_type` = 'insert_assignment' then concat('Add ',`PartOS`.`pubsname`,' to session') when `POSH`.`change_type` = 'remove_assignment' then concat('Remove ',`PartOS`.`pubsname`,' from session') when `POSH`.`change_type` = 'assign_moderator' then concat('Assign ',`PartOS`.`pubsname`,' as moderator') when `POSH`.`change_type` = 'remove_moderator' then concat('Unassign ',`PartOS`.`pubsname`,' as moderator') else 'Unknown action.' end AS `description`,`POSH`.`change_ts` AS `change_ts` from ((`participant_on_session_history` `POSH` join `Participants` `PartOS` on(`PartOS`.`badgeid` = `POSH`.`badgeid`)) join `Participants` `PartCR` on(`PartCR`.`badgeid` = `POSH`.`change_by_badgeid`))) */;
 /*!50001 SET character_set_client      = @saved_cs_client */;
 /*!50001 SET character_set_results     = @saved_cs_results */;


### PR DESCRIPTION
The most recent database dumps contain statements that require root permissions to execute. These are around security definers for triggers and views, that would allow the trigger/view to access tables the user doesn't have access to. In our case, we are assuming one user for all database operations, as this is the only option for many shared hosting plans. This change ensures that a user with general "create" permissions but no other special privileges can create the databases.

For the future, it might be worth looking at providing creation scripts that set up the database in a way that the application user could have minimal permissions, so that if an attacker were to gain access to the SQL user (for example, through a SQL injection attack), the damage they could cause would be limited. However, I think this would have to be an optional creation script to not exclude low-cost shared hosting plans.