### PR TITLE
Json extract object

### DIFF
--- a/webpages/StaffCreateKonOpas.php
+++ b/webpages/StaffCreateKonOpas.php
@@ -37,7 +37,7 @@
     $results = retrieveKonOpasData($showpubstatus, $showbio);
     $infofile = retrieveInfoData();
 
-    if ($results["message_error"]) {
+    if ($results["message_error"] ?? false) {
         error_log("StaffCreateKonOpas.php: " . $results["message_error"]);
         RenderError($results["message_error"]);
         exit();
@@ -100,8 +100,10 @@
     //Create data file for online guide ConClár
     //Should make this a flag or something to control whether to make the file.
     if ($results["json"]) {
-        $fileNameProd = JSON_EXTRACT_DIRECTORY . "konOpasData.json";
-        $fileNameTest = JSON_EXTRACT_DIRECTORY . "konOpasDataTest.json";
+        $filename = defined('JSON_EXTRACT_FILENAME') ? JSON_EXTRACT_FILENAME : "konOpasData";
+        $extension = defined('JSON_EXTRACT_EXTENSION') ? JSON_EXTRACT_EXTENSION : ".json";
+        $fileNameProd = JSON_EXTRACT_DIRECTORY . $filename . $extension;
+        $fileNameTest = JSON_EXTRACT_DIRECTORY . $filename . "Test" . $extension;
         $resultsFileProd = fopen($fileNameProd,"wb");
         $resultsFileTest = fopen($fileNameTest,"wb");
         if ($resultsFileProd === FALSE) {
@@ -132,7 +134,8 @@
         }
         fclose($resultsFileProd);
         fclose($resultsFileTest);
-        echo('<p>The ConClár data file was created.' . "\n");
+        echo("<p>The ConClár prod data file $fileNameProd was created.\n");
+        echo("<p>The ConClár test data file $fileNameTest was created.\n");
 
     }
     if (empty($results)) {
@@ -143,7 +146,7 @@
     }
 
     //Create info file for online guide ConClár
-    if ($infofile["message_error"]) {
+    if ($infofile["message_error"] ?? false) {
         error_log("StaffCreateKonOpas.php: " . $infofile["message_error"]);
         RenderError($infofile["message_error"]);
         exit();

--- a/webpages/config/db_name_sample.php
+++ b/webpages/config/db_name_sample.php
@@ -123,7 +123,11 @@ define("PHOTO_DIMENSIONS", "200,200,800,800,1048576"); // comma separated list: 
 define("PHOTO_DEFAULT_IMAGE", "default.png"); // placeholder image for participants without photo
 
 define("JSON_EXTRACT_DIRECTORY", "/var/data/guide/");  // Path to directory where Konopas/ConClár files to be written.
+define("JSON_EXTRACT_FILENAME", "konOpasData");  // File name of combined Konopas/ConClár file (note: program.js and participants.js are also extacted).
+define("JSON_EXTRACT_EXTENSION", ".json");  // File extension of Konopas/ConClár file.
 define("JSON_EXTRACT_ASSIGN_VARS", FALSE); // If TRUE include variable names in JSON output files (required for KonOpas).
+define("JSON_EXTRACT_OBJECT", FALSE); // If TRUE, wrap the program and participant data in a JSON. Strictly, to be valid JSON, the top level should be an object.
+define('JSON_EXTRACT_FLAGS', 0); // See `json_encode` docuentation for available flags. Use `JSON_PRETTY_PRINT` to format human readable JSON output (useful for debugging, but bigger output files).
 define("OBS_EXTRACT_DIRECTORY", "obs"); // Path to directory for OBS files, relative to web root.
 define('OBS_EXTRACT_TAGS', ''); // Comma separated list of Tags to generate OBS extracts for.
         // Prefix Tag with ~ in list to extract all items without tag.

--- a/webpages/konOpas_func.php
+++ b/webpages/konOpas_func.php
@@ -195,13 +195,14 @@ EOD;
     }
 
     // Encode program and people as JSON.
+    $jsonFlags = defined('JSON_EXTRACT_FLAGS') ? JSON_EXTRACT_FLAGS : 0;
     if (defined('JSON_EXTRACT_ASSIGN_VARS') && JSON_EXTRACT_ASSIGN_VARS) {
-        $programJson = "var program = " . json_encode(wrapInObject($program, 'program')).";\n";
-        $peopleJson = "var people = " . json_encode(wrapInObject($people, 'people')).";\n";
+        $programJson = "var program = " . json_encode(wrapInObject($program, 'program'), $jsonFlags).";\n";
+        $peopleJson = "var people = " . json_encode(wrapInObject($people, 'people'), $jsonFlags).";\n";
     }
     else {
-        $programJson = json_encode(wrapInObject($program, 'program'));
-        $peopleJson = json_encode(wrapInObject($people, 'people'));
+        $programJson = json_encode(wrapInObject($program, 'program'), $jsonFlags);
+        $peopleJson = json_encode(wrapInObject($people, 'people'), $jsonFlags);
     }
 
     //The json key is for general json output
@@ -209,7 +210,7 @@ EOD;
         $results["json"] = json_encode([
             'program' => $program,
             'people' => $people,
-        ], defined('JSON_EXTRACT_FLAGS') ? JSON_EXTRACT_FLAGS : 0);
+        ], $jsonFlags);
     }
     else {
         $results["json"]  = $programJson;

--- a/webpages/konOpas_func.php
+++ b/webpages/konOpas_func.php
@@ -164,12 +164,12 @@ EOD;
         $links = [];
         if (defined('PHOTO_EXTRACT_LINK_TYPE') && !empty(PHOTO_EXTRACT_LINK_TYPE) && !empty($row['approvedphotofilename'])) {
             // Construct link to photo image on current server.
-            $links[PHOTO_EXTRACT_LINK_TYPE] = 'http' 
-                                            . ($_SERVER['HTTPS'] ? 's' : '') 
-                                            . '://' 
-                                            . $_SERVER['SERVER_NAME'] 
-                                            . PHOTO_PUBLIC_DIRECTORY 
-                                            . '/' 
+            $links[PHOTO_EXTRACT_LINK_TYPE] = 'http'
+                                            . ($_SERVER['HTTPS'] ? 's' : '')
+                                            . '://'
+                                            . $_SERVER['SERVER_NAME']
+                                            . PHOTO_PUBLIC_DIRECTORY
+                                            . '/'
                                             . $row['approvedphotofilename'];
         }
         $peopleRow = array(
@@ -185,19 +185,36 @@ EOD;
 
     //note:header('Content-type: application/json');
 
+    function wrapInObject(array $data, string $key) {
+        if (defined('JSON_EXTRACT_OBJECT') && JSON_EXTRACT_OBJECT) {
+            return [$key => $data];
+        }
+        else {
+            return $data;
+        }
+    }
+
     // Encode program and people as JSON.
     if (defined('JSON_EXTRACT_ASSIGN_VARS') && JSON_EXTRACT_ASSIGN_VARS) {
-        $programJson = "var program = " . json_encode($program).";\n";
-        $peopleJson = "var people = " . json_encode($people).";\n";
+        $programJson = "var program = " . json_encode(wrapInObject($program, 'program')).";\n";
+        $peopleJson = "var people = " . json_encode(wrapInObject($people, 'people')).";\n";
     }
     else {
-        $programJson = json_encode($program);
-        $peopleJson = json_encode($people);
+        $programJson = json_encode(wrapInObject($program, 'program'));
+        $peopleJson = json_encode(wrapInObject($people, 'people'));
     }
 
     //The json key is for general json output
-    $results["json"]  = $programJson;
-    $results["json"] .= $peopleJson;
+    if (defined('JSON_EXTRACT_OBJECT') && JSON_EXTRACT_OBJECT) {
+        $results["json"] = json_encode([
+            'program' => $program,
+            'people' => $people,
+        ], defined('JSON_EXTRACT_FLAGS') ? JSON_EXTRACT_FLAGS : 0);
+    }
+    else {
+        $results["json"]  = $programJson;
+        $results["json"] .= $peopleJson;
+    }
 
     //The program, people and konopas keys are for KonOpas
     $results["program"]  = $programJson;
@@ -259,7 +276,7 @@ EOD;
         $lochoursstr = str_replace(array("<em>", "</em>"), array("*", "*"), $lochoursstr);
         $lochoursstr = str_replace(array("<u>", "</u>"), array("**", "**"), $lochoursstr);
         $lochoursstr = str_replace(array("<strong>", "</strong>"), array("***", "***"), $lochoursstr);
-        
+
         $locations["output"] .= $lochoursstr . "\n";
     }
 

--- a/webpages/konOpas_func.php
+++ b/webpages/konOpas_func.php
@@ -185,7 +185,18 @@ EOD;
 
     //note:header('Content-type: application/json');
 
-    function wrapInObject(array $data, string $key) {
+    /**
+     * Wrap array in an object.
+     *
+     * If JSON_EXTRACT_OBJECT is true, the returned array will place the data in
+     * an associative array. If false, the data array is returned unchanged.
+     *
+     * @param array $data Data array to wrap with an object.
+     * @param string $key The property name of the data should be assigned to.
+     *
+     * @return array The associative array with the data array referenced by the key.
+     */
+    function wrapInObject(array $data, string $key): array {
         if (defined('JSON_EXTRACT_OBJECT') && JSON_EXTRACT_OBJECT) {
             return [$key => $data];
         }


### PR DESCRIPTION
The KonOpas/ConClár extract outputs JSON files. However the top level of the JSON is the array of program items or people.

However, to be valid JSON the top level should be an object, rather than an array.

With this change, if `JSON_EXTRACT_OBJECT` is true, the JSON output will be wrapped in an object as follows:

- program.js will contain an object with a single property `program`, containing the sessions.
- people.js will contain an object with a property `people`, containing the array of participants.
- A third file called konOpasData.json by default will contain a single object, with two properties, `program` and `people`, as above.

Additionally, while the third file defaults to `konOpasData.json`, the filename can be overridden by `JSON_EXTRACT_FILENAME` and `JSON_EXTRACT_EXTENSION` settings.

This change also adds a setting, `JSON_EXTRACT_FLAGS`. This can be set to any flags defined in the `json_encode` documentation. These flags will be passed into `json_extract` calls. If set to `JSON_PRETTY_PRINT`, the output JSON will be in a human readable format.

I've made all the new settings revert to their existing values if not present.