### PR TITLE
Saving "Availability" sometimes fails without error.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,77 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    services:
+      mariadb:
+        image: mariadb:10.3
+        env:
+          MARIADB_DATABASE: db
+          MARIADB_USER: db
+          MARIADB_PASSWORD: db
+          MARIADB_ROOT_PASSWORD: root
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping --silent"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+          extensions: mysqli, dom, xsl, mbstring
+          coverage: none
+
+      - name: Install test tooling (PHPUnit)
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Install app runtime dependencies
+        working-directory: webpages
+        run: composer install --no-interaction --prefer-dist --no-dev
+
+      - name: Load database schema
+        run: mysql -h 127.0.0.1 -P 3306 -u db -pdb db < Install/EmptyDbase.dump
+
+      - name: Configure app for the CI database
+        run: |
+          cp webpages/config/db_name_sample.php webpages/config/db_name.php
+          cp webpages/config/db_env_sample.php webpages/config/db_env.php
+          # db_name_sample.php normally pulls DB credentials from a system-wide
+          # /etc/planz/db_env_sample.php; point it at our generated db_env.php instead.
+          sed -i "s#'/etc/planz/db_env_sample.php'#(__DIR__ . '/db_env.php')#g" webpages/config/db_name.php
+          sed -i \
+            -e 's/define("DBHOSTNAME", "");/define("DBHOSTNAME", "127.0.0.1");/' \
+            -e 's/define("DBUSERID", getenv("MYSQL_USER"));/define("DBUSERID", "db");/' \
+            -e 's/define("DBPASSWORD", getenv("MYSQL_PASSWORD"));/define("DBPASSWORD", "db");/' \
+            -e 's/define("DBDB", "");/define("DBDB", "db");/' \
+            webpages/config/db_env.php
+
+      - name: Start the app (PHP built-in server)
+        working-directory: webpages
+        run: |
+          php -S 127.0.0.1:8080 >/tmp/php-server.log 2>&1 &
+          for i in $(seq 1 20); do
+            curl -sf http://127.0.0.1:8080/login.php >/dev/null && exit 0
+            sleep 1
+          done
+          echo "App server did not become ready in time" >&2
+          cat /tmp/php-server.log >&2
+          exit 1
+
+      - name: Run tests
+        env:
+          PLANZ_TEST_BASE_URL: http://127.0.0.1:8080
+        run: vendor/bin/phpunit

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@ upload_photos/
 #Exclude devtools folders.
 .ddev
 .vscode
+
+# Test tooling (root-level composer.json; kept separate from webpages/vendor/).
+/vendor/
+/.phpunit.cache/

--- a/Install/Upgrade_dbase/100ZED_utf8mb4_migration.sql
+++ b/Install/Upgrade_dbase/100ZED_utf8mb4_migration.sql
@@ -1,0 +1,116 @@
+## This script converts the database and every existing table from utf8 (3-byte) to
+## utf8mb4 (4-byte), so that free-text fields (e.g. My Availability's "prevent conflict"
+## and "other constraints", participant bios, session descriptions, etc.) can actually
+## store emoji and other characters outside the Basic Multilingual Plane, instead of
+## the save failing.
+##
+## utf8mb4_general_ci is used (rather than utf8mb4_unicode_ci) because it is the direct
+## 4-byte analog of utf8_general_ci, which every table already uses: it keeps existing
+## sorting/comparison behavior unchanged, so this is a storage-width change only, not a
+## collation-behavior change.
+##
+## Foreign key checks are disabled for the duration of the conversion. Converting a
+## child table's charset before its parent's (or vice versa) can otherwise be rejected
+## by InnoDB even though every table ends up on utf8mb4/utf8mb4_general_ci once the
+## whole script has run.
+##
+## Note: this changes storage/comparison behavior only. The application's connection
+## charset (mysqli_set_charset() in webpages/db_functions.php) also needs to move from
+## "utf8" to "utf8mb4" for the app to actually be able to send/receive 4-byte characters
+## over the connection — that is a separate code change, tracked alongside this patch.
+##
+## Created by James Shields on 2026-08-24
+## Copyright (c) 2020 by Peter Olszowka. All rights reserved. See copyright document for more details.
+##
+
+SET FOREIGN_KEY_CHECKS=0;
+
+ALTER DATABASE CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+
+ALTER TABLE `AgeRanges` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `BioEditStatuses` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `CongoDump` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `CongoDumpHistory` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `Credentials` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `CustomText` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `Divisions` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `EmailCC` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `EmailFrom` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `EmailHistory` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `EmailQueue` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `EmailTo` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `Features` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `Interests` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `KidsCategories` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `LanguageStatuses` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `Locations` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `ParticipantAvailability` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `ParticipantAvailabilityDays` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `ParticipantAvailabilityTimes` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `ParticipantDetails` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `ParticipantHasCredential` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `ParticipantHasInterest` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `ParticipantHasRole` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `ParticipantInterests` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `ParticipantOnSession` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `ParticipantPasswordResetRequests` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `ParticipantSessionInterest` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `ParticipantSuggestions` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `ParticipantSurveyAnswers` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `Participants` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `PatchLog` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `PermissionAtoms` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `PermissionRoles` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `Permissions` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `Phases` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `PhotoDenialReasons` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `PhotoUploadStatus` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `PreviousConTracks` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `PreviousParticipants` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `PreviousSessions` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `Pronouns` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `PubStatuses` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `RegTypes` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `Roles` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `RoomColors` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `RoomHasSet` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `RoomSets` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `Rooms` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `Schedule` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `ServiceTypes` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `Services` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `SessionEditCodes` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `SessionEditHistory` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `SessionHasFeature` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `SessionHasService` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `SessionHasTag` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `SessionStatuses` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `Sessions` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `SurveyQuestionConfig` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `SurveyQuestionOptionConfig` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `SurveyQuestionTypeDefaults` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `SurveyQuestionTypes` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `Tags` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `TechLevel` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `Times` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `TrackCompatibility` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `Tracks` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `Types` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `UserHasPermissionRole` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `con_info` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `con_key_dates` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `module` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `participant_has_volunteer_shift` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `participant_on_session_history` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `perennial_con_info` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `room_availability_schedule` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `room_availability_slot` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `room_report_group` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `room_report_group_has_room` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `room_to_availability` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `volunteer_job` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `volunteer_shift` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+
+SET FOREIGN_KEY_CHECKS=1;
+
+INSERT INTO PatchLog (patchname) VALUES ('100ZED_utf8mb4_migration.sql');

--- a/Install/Upgrade_dbase/100ZED_utf8mb4_migration.sql
+++ b/Install/Upgrade_dbase/100ZED_utf8mb4_migration.sql
@@ -9,21 +9,74 @@
 ## sorting/comparison behavior unchanged, so this is a storage-width change only, not a
 ## collation-behavior change.
 ##
-## Foreign key checks are disabled for the duration of the conversion. Converting a
-## child table's charset before its parent's (or vice versa) can otherwise be rejected
-## by InnoDB even though every table ends up on utf8mb4/utf8mb4_general_ci once the
-## whole script has run.
+## Every foreign key in the schema is dropped before the charset conversion and
+## recreated afterward. This is necessary, not just cautious: on MySQL 8.0,
+## ALTER TABLE ... CONVERT TO CHARACTER SET on a column used in a foreign key fails
+## with error 1832 ("Cannot change column ... used in a foreign key constraint") even
+## with FOREIGN_KEY_CHECKS=0 — that setting only suppresses referential-integrity
+## validation, not this separate metadata check MySQL 8.0 added. MariaDB (used in dev)
+## doesn't enforce this, which is why this didn't surface during development and only
+## showed up running this against a MySQL 8 database.
+##
+## The DROP/ADD FOREIGN KEY statements below are generated from this project's actual
+## schema (captured via information_schema, not hand-typed) rather than looped
+## dynamically in a stored procedure, even though that would be more resilient to
+## schema drift from Install/EmptyDbase.dump: some hosts (particularly shared/managed
+## MySQL hosting) restrict database users from CREATE PROCEDURE / mysql.proc access
+## even when they otherwise have full DDL rights, which surfaces as "ERROR 1728: Cannot
+## load from mysql.proc" — not a real corruption, just a permissions wall. Flat SQL
+## avoids that dependency entirely, at the cost of needing to be regenerated if the
+## schema's foreign keys change before this patch is applied everywhere it needs to run.
 ##
 ## Note: this changes storage/comparison behavior only. The application's connection
 ## charset (mysqli_set_charset() in webpages/db_functions.php) also needs to move from
 ## "utf8" to "utf8mb4" for the app to actually be able to send/receive 4-byte characters
 ## over the connection — that is a separate code change, tracked alongside this patch.
 ##
-## Created by James Shields on 2026-08-24
+## Created by James Shields on 2026-08-25
 ## Copyright (c) 2020 by Peter Olszowka. All rights reserved. See copyright document for more details.
 ##
 
 SET FOREIGN_KEY_CHECKS=0;
+
+-- Drop every foreign key in the schema (grouped per table) so the charset conversion
+-- below can run without MySQL 8.0's error 1832.
+ALTER TABLE `CongoDumpHistory` DROP FOREIGN KEY `CongoDumpHistory_ibfk_1`, DROP FOREIGN KEY `CongoDumpHistory_ibfk_2`, DROP FOREIGN KEY `CongoDumpHistory_ibfk_3`;
+ALTER TABLE `ParticipantAvailability` DROP FOREIGN KEY `ParticipantAvailability_ibfk_1`;
+ALTER TABLE `ParticipantAvailabilityDays` DROP FOREIGN KEY `ParticipantAvailabilityDays_ibfk_1`;
+ALTER TABLE `ParticipantAvailabilityTimes` DROP FOREIGN KEY `ParticipantAvailabilityTimes_ibfk_1`;
+ALTER TABLE `ParticipantDetails` DROP FOREIGN KEY `ParticipantDetails_ibfk_1`, DROP FOREIGN KEY `ParticipantDetails_ibfk_2`, DROP FOREIGN KEY `ParticipantDetails_ibfk_3`;
+ALTER TABLE `ParticipantHasCredential` DROP FOREIGN KEY `phcfk1`, DROP FOREIGN KEY `phcfk2`;
+ALTER TABLE `ParticipantHasInterest` DROP FOREIGN KEY `phifk1`, DROP FOREIGN KEY `phifk2`;
+ALTER TABLE `ParticipantHasRole` DROP FOREIGN KEY `ParticipantHasRole_ibfk_1`, DROP FOREIGN KEY `ParticipantHasRole_ibfk_2`;
+ALTER TABLE `ParticipantInterests` DROP FOREIGN KEY `ParticipantInterests_ibfk_1`;
+ALTER TABLE `ParticipantOnSession` DROP FOREIGN KEY `ParticipantOnSession_ibfk_1`, DROP FOREIGN KEY `ParticipantOnSession_ibfk_2`;
+ALTER TABLE `ParticipantSessionInterest` DROP FOREIGN KEY `ParticipantSessionInterest_ibfk_1`, DROP FOREIGN KEY `ParticipantSessionInterest_ibfk_2`, DROP FOREIGN KEY `ParticipantSessionInterest_ibfk_3`, DROP FOREIGN KEY `ParticipantSessionInterest_ibfk_4`;
+ALTER TABLE `ParticipantSuggestions` DROP FOREIGN KEY `ParticipantSuggestions_ibfk_1`;
+ALTER TABLE `ParticipantSurveyAnswers` DROP FOREIGN KEY `ParticipantSurveyAnswers_ibfk_1`, DROP FOREIGN KEY `ParticipantSurveyAnswers_ibfk_2`;
+ALTER TABLE `Participants` DROP FOREIGN KEY `Participants_photodeny`, DROP FOREIGN KEY `participantphotostatus_fk`;
+ALTER TABLE `Permissions` DROP FOREIGN KEY `Permissions_ibfk_1`, DROP FOREIGN KEY `Permissions_ibfk_2`, DROP FOREIGN KEY `Permissions_ibfk_3`;
+ALTER TABLE `PreviousConTracks` DROP FOREIGN KEY `PreviousCons_ibfk_1`;
+ALTER TABLE `PreviousSessions` DROP FOREIGN KEY `PreviousSessions_ibfk_1`, DROP FOREIGN KEY `PreviousSessions_ibfk_2`, DROP FOREIGN KEY `PreviousSessions_ibfk_3`, DROP FOREIGN KEY `PreviousSessions_ibfk_4`, DROP FOREIGN KEY `PreviousSessions_ibfk_5`, DROP FOREIGN KEY `PreviousSessions_ibfk_6`, DROP FOREIGN KEY `PreviousSessions_ibfk_7`;
+ALTER TABLE `RoomHasSet` DROP FOREIGN KEY `RoomHasSet_ibfk_1`, DROP FOREIGN KEY `RoomHasSet_ibfk_2`;
+ALTER TABLE `Rooms` DROP FOREIGN KEY `Rooms_ibfk_1`;
+ALTER TABLE `Schedule` DROP FOREIGN KEY `Schedule_ibfk_1`, DROP FOREIGN KEY `Schedule_ibfk_2`;
+ALTER TABLE `SessionEditHistory` DROP FOREIGN KEY `SessionEditHistory_ibfk_1`, DROP FOREIGN KEY `SessionEditHistory_ibfk_2`, DROP FOREIGN KEY `SessionEditHistory_ibfk_3`, DROP FOREIGN KEY `SessionEditHistory_ibfk_4`;
+ALTER TABLE `SessionHasFeature` DROP FOREIGN KEY `SessionHasFeature_ibfk_1`, DROP FOREIGN KEY `SessionHasFeature_ibfk_2`;
+ALTER TABLE `SessionHasService` DROP FOREIGN KEY `SessionHasService_ibfk_1`, DROP FOREIGN KEY `SessionHasService_ibfk_2`;
+ALTER TABLE `SessionHasTag` DROP FOREIGN KEY `Fkey1`, DROP FOREIGN KEY `Fkey2`;
+ALTER TABLE `Sessions` DROP FOREIGN KEY `Sessions_ibfk_1`, DROP FOREIGN KEY `Sessions_ibfk_2`, DROP FOREIGN KEY `Sessions_ibfk_3`, DROP FOREIGN KEY `Sessions_ibfk_4`, DROP FOREIGN KEY `Sessions_ibfk_5`, DROP FOREIGN KEY `Sessions_ibfk_6`, DROP FOREIGN KEY `Sessions_ibfk_7`, DROP FOREIGN KEY `Sessions_ibfk_8`, DROP FOREIGN KEY `Sessions_tlfk`;
+ALTER TABLE `SurveyQuestionConfig` DROP FOREIGN KEY `SurveyQuestionConfig_ibfk_1`;
+ALTER TABLE `SurveyQuestionOptionConfig` DROP FOREIGN KEY `SurveyQuestionOptionConfig_ibfk_1`;
+ALTER TABLE `SurveyQuestionTypeDefaults` DROP FOREIGN KEY `SurveyQuestionTypeDefaults_ibfk_1`;
+ALTER TABLE `TrackCompatibility` DROP FOREIGN KEY `TrackCompatibility_ibfk_1`, DROP FOREIGN KEY `TrackCompatibility_ibfk_2`;
+ALTER TABLE `Tracks` DROP FOREIGN KEY `Tracks_ibfk_1`;
+ALTER TABLE `UserHasPermissionRole` DROP FOREIGN KEY `UserHasPermissionRole_ibfk_1`, DROP FOREIGN KEY `UserHasPermissionRole_ibfk_2`;
+ALTER TABLE `con_info` DROP FOREIGN KEY `con_info_ibfk_1`;
+ALTER TABLE `participant_has_volunteer_shift` DROP FOREIGN KEY `fk_participant_has_shift_to_shift`, DROP FOREIGN KEY `fk_participant_to_participant_has_shift`;
+ALTER TABLE `participant_on_session_history` DROP FOREIGN KEY `participant_on_session_history_ibfk_1`, DROP FOREIGN KEY `participant_on_session_history_ibfk_2`, DROP FOREIGN KEY `participant_on_session_history_ibfk_3`;
+ALTER TABLE `room_report_group_has_room` DROP FOREIGN KEY `FK__room_report_group_has_room__room_report_group`, DROP FOREIGN KEY `FK__room_report_group_has_room__rooms`;
+ALTER TABLE `volunteer_shift` DROP FOREIGN KEY `fk_volunteer_shift_con_id`, DROP FOREIGN KEY `fk_volunteer_shift_to_volunteer_job`;
 
 ALTER DATABASE CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
 
@@ -110,6 +163,44 @@ ALTER TABLE `room_report_group_has_room` CONVERT TO CHARACTER SET utf8mb4 COLLAT
 ALTER TABLE `room_to_availability` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
 ALTER TABLE `volunteer_job` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
 ALTER TABLE `volunteer_shift` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+
+-- Recreate every foreign key exactly as it was, grouped per table.
+ALTER TABLE `CongoDumpHistory` ADD CONSTRAINT `CongoDumpHistory_ibfk_1` FOREIGN KEY (`badgeid`) REFERENCES `Participants` (`badgeid`), ADD CONSTRAINT `CongoDumpHistory_ibfk_2` FOREIGN KEY (`createdbybadgeid`) REFERENCES `Participants` (`badgeid`), ADD CONSTRAINT `CongoDumpHistory_ibfk_3` FOREIGN KEY (`inactivatedbybadgeid`) REFERENCES `Participants` (`badgeid`);
+ALTER TABLE `ParticipantAvailability` ADD CONSTRAINT `ParticipantAvailability_ibfk_1` FOREIGN KEY (`badgeid`) REFERENCES `Participants` (`badgeid`);
+ALTER TABLE `ParticipantAvailabilityDays` ADD CONSTRAINT `ParticipantAvailabilityDays_ibfk_1` FOREIGN KEY (`badgeid`) REFERENCES `Participants` (`badgeid`);
+ALTER TABLE `ParticipantAvailabilityTimes` ADD CONSTRAINT `ParticipantAvailabilityTimes_ibfk_1` FOREIGN KEY (`badgeid`) REFERENCES `Participants` (`badgeid`);
+ALTER TABLE `ParticipantDetails` ADD CONSTRAINT `ParticipantDetails_ibfk_1` FOREIGN KEY (`badgeid`) REFERENCES `Participants` (`badgeid`), ADD CONSTRAINT `ParticipantDetails_ibfk_2` FOREIGN KEY (`agerangeid`) REFERENCES `AgeRanges` (`agerangeid`), ADD CONSTRAINT `ParticipantDetails_ibfk_3` FOREIGN KEY (`pronounid`) REFERENCES `Pronouns` (`pronounid`);
+ALTER TABLE `ParticipantHasCredential` ADD CONSTRAINT `phcfk1` FOREIGN KEY (`badgeid`) REFERENCES `Participants` (`badgeid`), ADD CONSTRAINT `phcfk2` FOREIGN KEY (`credentialid`) REFERENCES `Credentials` (`credentialid`);
+ALTER TABLE `ParticipantHasInterest` ADD CONSTRAINT `phifk1` FOREIGN KEY (`badgeid`) REFERENCES `Participants` (`badgeid`), ADD CONSTRAINT `phifk2` FOREIGN KEY (`interestid`) REFERENCES `Interests` (`interestid`);
+ALTER TABLE `ParticipantHasRole` ADD CONSTRAINT `ParticipantHasRole_ibfk_1` FOREIGN KEY (`badgeid`) REFERENCES `Participants` (`badgeid`), ADD CONSTRAINT `ParticipantHasRole_ibfk_2` FOREIGN KEY (`roleid`) REFERENCES `Roles` (`roleid`);
+ALTER TABLE `ParticipantInterests` ADD CONSTRAINT `ParticipantInterests_ibfk_1` FOREIGN KEY (`badgeid`) REFERENCES `Participants` (`badgeid`);
+ALTER TABLE `ParticipantOnSession` ADD CONSTRAINT `ParticipantOnSession_ibfk_1` FOREIGN KEY (`badgeid`) REFERENCES `Participants` (`badgeid`), ADD CONSTRAINT `ParticipantOnSession_ibfk_2` FOREIGN KEY (`sessionid`) REFERENCES `Sessions` (`sessionid`);
+ALTER TABLE `ParticipantSessionInterest` ADD CONSTRAINT `ParticipantSessionInterest_ibfk_1` FOREIGN KEY (`badgeid`) REFERENCES `Participants` (`badgeid`), ADD CONSTRAINT `ParticipantSessionInterest_ibfk_2` FOREIGN KEY (`sessionid`) REFERENCES `Sessions` (`sessionid`), ADD CONSTRAINT `ParticipantSessionInterest_ibfk_3` FOREIGN KEY (`badgeid`) REFERENCES `Participants` (`badgeid`), ADD CONSTRAINT `ParticipantSessionInterest_ibfk_4` FOREIGN KEY (`sessionid`) REFERENCES `Sessions` (`sessionid`);
+ALTER TABLE `ParticipantSuggestions` ADD CONSTRAINT `ParticipantSuggestions_ibfk_1` FOREIGN KEY (`badgeid`) REFERENCES `Participants` (`badgeid`);
+ALTER TABLE `ParticipantSurveyAnswers` ADD CONSTRAINT `ParticipantSurveyAnswers_ibfk_1` FOREIGN KEY (`participantid`) REFERENCES `Participants` (`badgeid`) ON DELETE CASCADE, ADD CONSTRAINT `ParticipantSurveyAnswers_ibfk_2` FOREIGN KEY (`questionid`) REFERENCES `SurveyQuestionConfig` (`questionid`) ON DELETE CASCADE;
+ALTER TABLE `Participants` ADD CONSTRAINT `Participants_photodeny` FOREIGN KEY (`photodenialreasonid`) REFERENCES `PhotoDenialReasons` (`photodenialreasonid`), ADD CONSTRAINT `participantphotostatus_fk` FOREIGN KEY (`photouploadstatus`) REFERENCES `PhotoUploadStatus` (`photouploadstatus`);
+ALTER TABLE `Permissions` ADD CONSTRAINT `Permissions_ibfk_1` FOREIGN KEY (`permatomid`) REFERENCES `PermissionAtoms` (`permatomid`), ADD CONSTRAINT `Permissions_ibfk_2` FOREIGN KEY (`phaseid`) REFERENCES `Phases` (`phaseid`), ADD CONSTRAINT `Permissions_ibfk_3` FOREIGN KEY (`permroleid`) REFERENCES `PermissionRoles` (`permroleid`);
+ALTER TABLE `PreviousConTracks` ADD CONSTRAINT `PreviousCons_ibfk_1` FOREIGN KEY (`previousconid`) REFERENCES `con_info` (`id`);
+ALTER TABLE `PreviousSessions` ADD CONSTRAINT `PreviousSessions_ibfk_1` FOREIGN KEY (`previousconid`) REFERENCES `con_info` (`id`), ADD CONSTRAINT `PreviousSessions_ibfk_2` FOREIGN KEY (`previousconid`,`previoustrackid`) REFERENCES `PreviousConTracks` (`previousconid`,`previoustrackid`), ADD CONSTRAINT `PreviousSessions_ibfk_3` FOREIGN KEY (`previousstatusid`) REFERENCES `SessionStatuses` (`statusid`), ADD CONSTRAINT `PreviousSessions_ibfk_4` FOREIGN KEY (`typeid`) REFERENCES `Types` (`typeid`), ADD CONSTRAINT `PreviousSessions_ibfk_5` FOREIGN KEY (`divisionid`) REFERENCES `Divisions` (`divisionid`), ADD CONSTRAINT `PreviousSessions_ibfk_6` FOREIGN KEY (`languagestatusid`) REFERENCES `LanguageStatuses` (`languagestatusid`), ADD CONSTRAINT `PreviousSessions_ibfk_7` FOREIGN KEY (`kidscatid`) REFERENCES `KidsCategories` (`kidscatid`);
+ALTER TABLE `RoomHasSet` ADD CONSTRAINT `RoomHasSet_ibfk_1` FOREIGN KEY (`roomid`) REFERENCES `Rooms` (`roomid`), ADD CONSTRAINT `RoomHasSet_ibfk_2` FOREIGN KEY (`roomsetid`) REFERENCES `RoomSets` (`roomsetid`);
+ALTER TABLE `Rooms` ADD CONSTRAINT `Rooms_ibfk_1` FOREIGN KEY (`roomcolorid`) REFERENCES `RoomColors` (`roomcolorid`);
+ALTER TABLE `Schedule` ADD CONSTRAINT `Schedule_ibfk_1` FOREIGN KEY (`sessionid`) REFERENCES `Sessions` (`sessionid`), ADD CONSTRAINT `Schedule_ibfk_2` FOREIGN KEY (`roomid`) REFERENCES `Rooms` (`roomid`);
+ALTER TABLE `SessionEditHistory` ADD CONSTRAINT `SessionEditHistory_ibfk_1` FOREIGN KEY (`sessionid`) REFERENCES `Sessions` (`sessionid`), ADD CONSTRAINT `SessionEditHistory_ibfk_2` FOREIGN KEY (`badgeid`) REFERENCES `Participants` (`badgeid`), ADD CONSTRAINT `SessionEditHistory_ibfk_3` FOREIGN KEY (`sessioneditcode`) REFERENCES `SessionEditCodes` (`sessioneditcode`), ADD CONSTRAINT `SessionEditHistory_ibfk_4` FOREIGN KEY (`statusid`) REFERENCES `SessionStatuses` (`statusid`);
+ALTER TABLE `SessionHasFeature` ADD CONSTRAINT `SessionHasFeature_ibfk_1` FOREIGN KEY (`sessionid`) REFERENCES `Sessions` (`sessionid`), ADD CONSTRAINT `SessionHasFeature_ibfk_2` FOREIGN KEY (`featureid`) REFERENCES `Features` (`featureid`);
+ALTER TABLE `SessionHasService` ADD CONSTRAINT `SessionHasService_ibfk_1` FOREIGN KEY (`sessionid`) REFERENCES `Sessions` (`sessionid`), ADD CONSTRAINT `SessionHasService_ibfk_2` FOREIGN KEY (`serviceid`) REFERENCES `Services` (`serviceid`);
+ALTER TABLE `SessionHasTag` ADD CONSTRAINT `Fkey1` FOREIGN KEY (`sessionid`) REFERENCES `Sessions` (`sessionid`), ADD CONSTRAINT `Fkey2` FOREIGN KEY (`tagid`) REFERENCES `Tags` (`tagid`);
+ALTER TABLE `Sessions` ADD CONSTRAINT `Sessions_ibfk_1` FOREIGN KEY (`trackid`) REFERENCES `Tracks` (`trackid`), ADD CONSTRAINT `Sessions_ibfk_2` FOREIGN KEY (`typeid`) REFERENCES `Types` (`typeid`), ADD CONSTRAINT `Sessions_ibfk_3` FOREIGN KEY (`kidscatid`) REFERENCES `KidsCategories` (`kidscatid`), ADD CONSTRAINT `Sessions_ibfk_4` FOREIGN KEY (`roomsetid`) REFERENCES `RoomSets` (`roomsetid`), ADD CONSTRAINT `Sessions_ibfk_5` FOREIGN KEY (`statusid`) REFERENCES `SessionStatuses` (`statusid`), ADD CONSTRAINT `Sessions_ibfk_6` FOREIGN KEY (`pubstatusid`) REFERENCES `PubStatuses` (`pubstatusid`), ADD CONSTRAINT `Sessions_ibfk_7` FOREIGN KEY (`divisionid`) REFERENCES `Divisions` (`divisionid`), ADD CONSTRAINT `Sessions_ibfk_8` FOREIGN KEY (`languagestatusid`) REFERENCES `LanguageStatuses` (`languagestatusid`), ADD CONSTRAINT `Sessions_tlfk` FOREIGN KEY (`techlevelid`) REFERENCES `TechLevel` (`techlevelid`);
+ALTER TABLE `SurveyQuestionConfig` ADD CONSTRAINT `SurveyQuestionConfig_ibfk_1` FOREIGN KEY (`typeid`) REFERENCES `SurveyQuestionTypes` (`typeid`);
+ALTER TABLE `SurveyQuestionOptionConfig` ADD CONSTRAINT `SurveyQuestionOptionConfig_ibfk_1` FOREIGN KEY (`questionid`) REFERENCES `SurveyQuestionConfig` (`questionid`) ON DELETE CASCADE;
+ALTER TABLE `SurveyQuestionTypeDefaults` ADD CONSTRAINT `SurveyQuestionTypeDefaults_ibfk_1` FOREIGN KEY (`typeid`) REFERENCES `SurveyQuestionTypes` (`typeid`);
+ALTER TABLE `TrackCompatibility` ADD CONSTRAINT `TrackCompatibility_ibfk_1` FOREIGN KEY (`previousconid`,`previoustrackid`) REFERENCES `PreviousConTracks` (`previousconid`,`previoustrackid`), ADD CONSTRAINT `TrackCompatibility_ibfk_2` FOREIGN KEY (`currenttrackid`) REFERENCES `Tracks` (`trackid`);
+ALTER TABLE `Tracks` ADD CONSTRAINT `Tracks_ibfk_1` FOREIGN KEY (`divisionid`) REFERENCES `Divisions` (`divisionid`) ON UPDATE CASCADE ON DELETE SET NULL;
+ALTER TABLE `UserHasPermissionRole` ADD CONSTRAINT `UserHasPermissionRole_ibfk_1` FOREIGN KEY (`badgeid`) REFERENCES `Participants` (`badgeid`), ADD CONSTRAINT `UserHasPermissionRole_ibfk_2` FOREIGN KEY (`permroleid`) REFERENCES `PermissionRoles` (`permroleid`);
+ALTER TABLE `con_info` ADD CONSTRAINT `con_info_ibfk_1` FOREIGN KEY (`perennial_con_id`) REFERENCES `perennial_con_info` (`id`) ON DELETE CASCADE;
+ALTER TABLE `participant_has_volunteer_shift` ADD CONSTRAINT `fk_participant_has_shift_to_shift` FOREIGN KEY (`volunteer_shift_id`) REFERENCES `volunteer_shift` (`id`) ON DELETE CASCADE, ADD CONSTRAINT `fk_participant_to_participant_has_shift` FOREIGN KEY (`badgeid`) REFERENCES `Participants` (`badgeid`) ON DELETE CASCADE;
+ALTER TABLE `participant_on_session_history` ADD CONSTRAINT `participant_on_session_history_ibfk_1` FOREIGN KEY (`badgeid`) REFERENCES `Participants` (`badgeid`), ADD CONSTRAINT `participant_on_session_history_ibfk_2` FOREIGN KEY (`sessionid`) REFERENCES `Sessions` (`sessionid`), ADD CONSTRAINT `participant_on_session_history_ibfk_3` FOREIGN KEY (`change_by_badgeid`) REFERENCES `Participants` (`badgeid`);
+ALTER TABLE `room_report_group_has_room` ADD CONSTRAINT `FK__room_report_group_has_room__room_report_group` FOREIGN KEY (`room_report_group_id`) REFERENCES `room_report_group` (`id`), ADD CONSTRAINT `FK__room_report_group_has_room__rooms` FOREIGN KEY (`room_id`) REFERENCES `Rooms` (`roomid`);
+ALTER TABLE `volunteer_shift` ADD CONSTRAINT `fk_volunteer_shift_con_id` FOREIGN KEY (`con_id`) REFERENCES `con_info` (`id`), ADD CONSTRAINT `fk_volunteer_shift_to_volunteer_job` FOREIGN KEY (`volunteer_job_id`) REFERENCES `volunteer_job` (`id`) ON DELETE CASCADE;
 
 SET FOREIGN_KEY_CHECKS=1;
 

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,10 @@
+{
+    "name": "planz/tests",
+    "description": "Test tooling for PlanZ. Kept separate from webpages/composer.json so PHPUnit and test code never ship inside the web docroot (webpages/ is served directly by nginx).",
+    "require-dev": {
+        "phpunit/phpunit": "^10.5"
+    },
+    "config": {
+        "sort-packages": true
+    }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,1671 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "e3688af3534909c3785bcfee78edf57c",
+    "packages": [],
+    "packages-dev": [
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.14.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "8680aa248f8e07bc8fb43f56f0f5fc77a0c96aae"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/8680aa248f8e07bc8fb43f56f0f5fc77a0c96aae",
+                "reference": "8680aa248f8e07bc8fb43f56f0f5fc77a0c96aae",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.14.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/mnapoli",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-08-11T10:17:44+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v5.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.8.0"
+            },
+            "time": "2026-07-04T14:30:18+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
+            },
+            "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "10.1.16",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "7e308268858ed6baedc8704a304727d20bc07c77"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/7e308268858ed6baedc8704a304727d20bc07c77",
+                "reference": "7e308268858ed6baedc8704a304727d20bc07c77",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-xmlwriter": "*",
+                "nikic/php-parser": "^4.19.1 || ^5.1.0",
+                "php": ">=8.1",
+                "phpunit/php-file-iterator": "^4.1.0",
+                "phpunit/php-text-template": "^3.0.1",
+                "sebastian/code-unit-reverse-lookup": "^3.0.0",
+                "sebastian/complexity": "^3.2.0",
+                "sebastian/environment": "^6.1.0",
+                "sebastian/lines-of-code": "^2.0.2",
+                "sebastian/version": "^4.0.1",
+                "theseer/tokenizer": "^1.2.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.1"
+            },
+            "suggest": {
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "10.1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.16"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-08-22T04:31:57+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "4.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/a95037b6d9e608ba092da1b23931e537cadc3c3c",
+                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/4.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-08-31T06:24:48+00:00"
+        },
+        {
+            "name": "phpunit/php-invoker",
+            "version": "4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
+                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^10.0"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/4.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:56:09+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/0c7b06ff49e3d5072f057eb1fa59258bf287a748",
+                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/3.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-08-31T14:07:24+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "6.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/e2a2d67966e740530f4a3343fe2e030ffdc1161d",
+                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/6.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:57:52+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "10.5.64",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "0e8c1d19cea35ad97d4887f363d07c78e30fbf06"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/0e8c1d19cea35ad97d4887f363d07c78e30fbf06",
+                "reference": "0e8c1d19cea35ad97d4887f363d07c78e30fbf06",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-filter": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.13.4",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
+                "php": ">=8.1",
+                "phpunit/php-code-coverage": "^10.1.16",
+                "phpunit/php-file-iterator": "^4.1.0",
+                "phpunit/php-invoker": "^4.0.0",
+                "phpunit/php-text-template": "^3.0.1",
+                "phpunit/php-timer": "^6.0.0",
+                "sebastian/cli-parser": "^2.0.1",
+                "sebastian/code-unit": "^2.0.0",
+                "sebastian/comparator": "^5.0.5",
+                "sebastian/diff": "^5.1.1",
+                "sebastian/environment": "^6.1.0",
+                "sebastian/exporter": "^5.1.4",
+                "sebastian/global-state": "^6.0.2",
+                "sebastian/object-enumerator": "^5.0.0",
+                "sebastian/recursion-context": "^5.0.1",
+                "sebastian/type": "^4.0.0",
+                "sebastian/version": "^4.0.1"
+            },
+            "suggest": {
+                "ext-soap": "To be able to generate mocks based on WSDL files"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "10.5-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.64"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/sponsoring.html",
+                    "type": "other"
+                }
+            ],
+            "time": "2026-07-06T14:50:35+00:00"
+        },
+        {
+            "name": "sebastian/cli-parser",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "c34583b87e7b7a8055bf6c450c2c77ce32a24084"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/c34583b87e7b7a8055bf6c450c2c77ce32a24084",
+                "reference": "c34583b87e7b7a8055bf6c450c2c77ce32a24084",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/2.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T07:12:49+00:00"
+        },
+        {
+            "name": "sebastian/code-unit",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/a81fee9eef0b7a76af11d121767abc44c104e503",
+                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/2.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:58:43+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
+                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/3.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:59:15+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "5.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "55dfef806eb7dfeb6e7a6935601fef866f8ca48d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/55dfef806eb7dfeb6e7a6935601fef866f8ca48d",
+                "reference": "55dfef806eb7dfeb6e7a6935601fef866f8ca48d",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "sebastian/diff": "^5.0",
+                "sebastian/exporter": "^5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "security": "https://github.com/sebastianbergmann/comparator/security/policy",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/5.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-24T09:25:16+00:00"
+        },
+        {
+            "name": "sebastian/complexity",
+            "version": "3.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "68ff824baeae169ec9f2137158ee529584553799"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/68ff824baeae169ec9f2137158ee529584553799",
+                "reference": "68ff824baeae169ec9f2137158ee529584553799",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "security": "https://github.com/sebastianbergmann/complexity/security/policy",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/3.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-21T08:37:17+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "5.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "c41e007b4b62af48218231d6c2275e4c9b975b2e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/c41e007b4b62af48218231d6c2275e4c9b975b2e",
+                "reference": "c41e007b4b62af48218231d6c2275e4c9b975b2e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0",
+                "symfony/process": "^6.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "security": "https://github.com/sebastianbergmann/diff/security/policy",
+                "source": "https://github.com/sebastianbergmann/diff/tree/5.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T07:15:17+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "6.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "8074dbcd93529b357029f5cc5058fd3e43666984"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/8074dbcd93529b357029f5cc5058fd3e43666984",
+                "reference": "8074dbcd93529b357029f5cc5058fd3e43666984",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "https://github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "security": "https://github.com/sebastianbergmann/environment/security/policy",
+                "source": "https://github.com/sebastianbergmann/environment/tree/6.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-23T08:47:14+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "5.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "0735b90f4da94969541dac1da743446e276defa6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/0735b90f4da94969541dac1da743446e276defa6",
+                "reference": "0735b90f4da94969541dac1da743446e276defa6",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "sebastian/recursion-context": "^5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "security": "https://github.com/sebastianbergmann/exporter/security/policy",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/5.1.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-24T06:09:11+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "6.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "987bafff24ecc4c9ac418cab1145b96dd6e9cbd9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/987bafff24ecc4c9ac418cab1145b96dd6e9cbd9",
+                "reference": "987bafff24ecc4c9ac418cab1145b96dd6e9cbd9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "sebastian/object-reflector": "^3.0",
+                "sebastian/recursion-context": "^5.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "https://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "security": "https://github.com/sebastianbergmann/global-state/security/policy",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/6.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T07:19:19+00:00"
+        },
+        {
+            "name": "sebastian/lines-of-code",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "856e7f6a75a84e339195d48c556f23be2ebf75d0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/856e7f6a75a84e339195d48c556f23be2ebf75d0",
+                "reference": "856e7f6a75a84e339195d48c556f23be2ebf75d0",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/2.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-21T08:38:20+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "5.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/202d0e344a580d7f7d04b3fafce6933e59dae906",
+                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "sebastian/object-reflector": "^3.0",
+                "sebastian/recursion-context": "^5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/5.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T07:08:32+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/24ed13d98130f0e7122df55d06c5c4942a577957",
+                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/3.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T07:06:18+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "5.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "5d32fe257a9b39cb63146924d6b4e32a22d4502a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/5d32fe257a9b39cb63146924d6b4e32a22d4502a",
+                "reference": "5d32fe257a9b39cb63146924d6b4e32a22d4502a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "security": "https://github.com/sebastianbergmann/recursion-context/security/policy",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/5.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-08-11T05:27:39+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/462699a16464c3944eefc02ebdd77882bd3925bf",
+                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "source": "https://github.com/sebastianbergmann/type/tree/4.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T07:10:45+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c51fa83a5d8f43f1402e3f32a005e6262244ef17",
+                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "source": "https://github.com/sebastianbergmann/version/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-07T11:34:05+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-11-17T20:03:58+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {},
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="tests/bootstrap.php"
+         colors="true"
+         cacheDirectory=".phpunit.cache">
+    <testsuites>
+        <testsuite name="Unit">
+            <directory>tests/Unit</directory>
+        </testsuite>
+        <testsuite name="Functional">
+            <directory>tests/Functional</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/Functional/SubmitMySchedConstrAuthTest.php
+++ b/tests/Functional/SubmitMySchedConstrAuthTest.php
@@ -1,0 +1,100 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+// Regression coverage for the session/permission ordering bug found alongside the
+// utf8mb4 one: SubmitMySchedConstr.php used to perform its database writes before
+// checking whether the session was still valid, and the only check that existed
+// (participant_header()'s isLoggedIn() re-verification) ran at the very end, after
+// renderMySchedConstr.php had already decided what to render. A session that went
+// stale between page-load and submit (e.g. the participant's password changed, or
+// their role lost the my_availability permission) could therefore have its write
+// either succeed or fail with no confirmation ever reaching the user — see
+// SubmitMySchedConstr.php's isLoggedIn()/may_I() check, added right after the
+// includes and before any POST data is read.
+final class SubmitMySchedConstrAuthTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        TestDb::resetFixture();
+    }
+
+    protected function tearDown(): void
+    {
+        TestDb::dropFixture();
+    }
+
+    /** @param array<string,string> $overrides */
+    private function payload(array $overrides = []): array
+    {
+        $fields = [
+            'maxprog' => '3',
+            'availstartday_1' => '1',
+            'availstarttime_1' => '1',
+            'availendday_1' => '1',
+            'availendtime_1' => '3',
+            'preventconflict' => 'SHOULD NOT BE SAVED',
+            'otherconstraints' => 'SHOULD NOT BE SAVED',
+        ];
+        for ($day = 1; $day <= CON_NUM_DAYS; $day++) {
+            $fields["maxprogday$day"] = '1';
+        }
+        for ($i = 2; $i <= AVAILABILITY_ROWS; $i++) {
+            $fields["availstartday_$i"] = '0';
+            $fields["availstarttime_$i"] = '0';
+            $fields["availendday_$i"] = '0';
+            $fields["availendtime_$i"] = '0';
+        }
+        return array_merge($fields, $overrides);
+    }
+
+    public function testStaleSessionBlocksTheWriteAndShowsAMessage(): void
+    {
+        $sessionId = SessionForge::create(function (array &$session): void {
+            // Same effect as the participant's password changing after they logged in:
+            // isLoggedIn()'s DB re-check will no longer match this cached hash.
+            $session['hashedPassword'] = str_repeat('x', 60);
+        });
+
+        $client = new HttpClient();
+        $response = $client->postWithSessionId($sessionId, '/SubmitMySchedConstr.php', $this->payload());
+
+        $this->assertStringNotContainsString('Fatal error', $response['body']);
+        $this->assertNotEmpty(trim(strip_tags($response['body'])), 'A blocked save must never return a blank page.');
+        $this->assertStringContainsString(
+            'alert-danger',
+            $response['body'],
+            'A stale session must show a clear error rather than silently doing nothing.'
+        );
+        $this->assertNull(
+            TestDb::fetchAvailability(),
+            'The write must not happen when the session is no longer valid.'
+        );
+    }
+
+    public function testSessionMissingPermissionBlocksTheWriteAndShowsAMessage(): void
+    {
+        $sessionId = SessionForge::create(function (array &$session): void {
+            // Same effect as a staff member revoking the participant's my_availability
+            // permission after they logged in but before they submitted the form. The
+            // 'Participant' tag is kept so the page still renders a normal (not
+            // logged-out) header.
+            $session['permission_set'] = array_values(array_filter(
+                $session['permission_set'],
+                fn($tag) => $tag !== 'my_availability'
+            ));
+        });
+
+        $client = new HttpClient();
+        $response = $client->postWithSessionId($sessionId, '/SubmitMySchedConstr.php', $this->payload());
+
+        $this->assertStringContainsString(
+            'You do not currently have permission',
+            $response['body']
+        );
+        $this->assertNull(
+            TestDb::fetchAvailability(),
+            'The write must not happen once the my_availability permission is gone.'
+        );
+    }
+}

--- a/tests/Functional/SubmitMySchedConstrTest.php
+++ b/tests/Functional/SubmitMySchedConstrTest.php
@@ -1,0 +1,138 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+// End-to-end regression coverage for webpages/SubmitMySchedConstr.php, run as an
+// authenticated HTTP client against a live copy of the app (DDEV locally, PHP's
+// built-in server in CI) plus direct DB assertions. No production code is required
+// for these tests to run — that's what makes them usable to prove a fix works
+// without first changing anything.
+final class SubmitMySchedConstrTest extends TestCase
+{
+    private HttpClient $client;
+
+    protected function setUp(): void
+    {
+        TestDb::resetFixture();
+        $this->client = new HttpClient();
+        $login = $this->client->login(PLANZ_TEST_EMAIL, PLANZ_TEST_PASSWORD);
+        $this->assertStringContainsString(
+            'My Availability',
+            $this->client->get('/my_sched_constr.php')['body'],
+            'Fixture login did not reach the My Availability page — check TestDb::resetFixture() permissions setup.'
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        TestDb::dropFixture();
+    }
+
+    /** @param array<string,string> $overrides */
+    private function payload(array $overrides = []): array
+    {
+        $fields = [
+            'maxprog' => '3',
+            'availstartday_1' => '1',
+            'availstarttime_1' => '1',
+            'availendday_1' => '1',
+            'availendtime_1' => '3',
+            'preventconflict' => '',
+            'otherconstraints' => '',
+        ];
+        for ($day = 1; $day <= CON_NUM_DAYS; $day++) {
+            $fields["maxprogday$day"] = '1';
+        }
+        for ($i = 2; $i <= AVAILABILITY_ROWS; $i++) {
+            $fields["availstartday_$i"] = '0';
+            $fields["availstarttime_$i"] = '0';
+            $fields["availendday_$i"] = '0';
+            $fields["availendtime_$i"] = '0';
+        }
+        return array_merge($fields, $overrides);
+    }
+
+    public function testValidSubmissionIsConfirmedAndPersisted(): void
+    {
+        $response = $this->client->post('/SubmitMySchedConstr.php', $this->payload([
+            'preventconflict' => 'No panels before 10am please',
+        ]));
+
+        $this->assertStringContainsString('Database updated successfully', $response['body']);
+
+        $row = TestDb::fetchAvailability();
+        $this->assertNotNull($row, 'Save was confirmed but no ParticipantAvailability row exists.');
+        $this->assertSame('3', $row['maxprog']);
+        $this->assertSame('No panels before 10am please', $row['preventconflict']);
+
+        $times = TestDb::fetchAvailabilityTimes();
+        $this->assertCount(1, $times, 'Expected exactly the one submitted availability slot to be saved.');
+    }
+
+    public function testInvalidSubmissionShowsErrorAndSavesNothing(): void
+    {
+        $response = $this->client->post('/SubmitMySchedConstr.php', $this->payload([
+            // End time before start time on the same day: validate_participant_availability()
+            // should reject this.
+            'availstartday_1' => '2',
+            'availstarttime_1' => '3',
+            'availendday_1' => '2',
+            'availendtime_1' => '1',
+        ]));
+
+        $this->assertStringContainsString(
+            'alert-danger',
+            $response['body'],
+            'Invalid input must show a visible error, not save silently.'
+        );
+        $this->assertNull(
+            TestDb::fetchAvailability(),
+            'Validation was supposed to fail — nothing should have been written to the database.'
+        );
+    }
+
+    // Regression test for the bug reported against my_sched_constr.php: a participant
+    // could save successfully with no visible error, but the data never actually
+    // persisted. Root cause: PHP 8.1 changed mysqli's default error-reporting mode to
+    // throw mysqli_sql_exception instead of returning false, but this app was written
+    // assuming the old "returns false" behavior and never calls
+    // mysqli_report(MYSQLI_REPORT_OFF). A 4-byte UTF-8 character (e.g. an emoji) in a
+    // free-text field fails against the ParticipantAvailability table's utf8 (3-byte)
+    // charset, which used to trigger the app's own friendly "Error updating database"
+    // message and now instead throws an uncaught exception straight through — a blank
+    // or broken page, and nothing saved, with no error shown to the user.
+    public function testEmojiInFreeTextDoesNotCrashOrSilentlyDropTheSave(): void
+    {
+        $response = $this->client->post('/SubmitMySchedConstr.php', $this->payload([
+            'preventconflict' => "No conflicts please \u{1F600}",
+        ]));
+
+        $this->assertStringNotContainsString(
+            'Fatal error',
+            $response['body'],
+            'A save must never surface a raw PHP fatal error to the user.'
+        );
+        $this->assertNotEmpty(
+            trim(strip_tags($response['body'])),
+            'A save attempt must never return a blank page with no feedback at all.'
+        );
+
+        $row = TestDb::fetchAvailability();
+        $claimsSuccess = str_contains($response['body'], 'Database updated successfully');
+
+        if ($claimsSuccess) {
+            $this->assertNotNull($row, 'Page claimed success, but no row was persisted.');
+            $this->assertStringContainsString(
+                'No conflicts please',
+                $row['preventconflict'] ?? '',
+                'Page claimed success, but the saved value does not match what was submitted.'
+            );
+        } else {
+            $this->assertStringContainsString(
+                'alert-danger',
+                $response['body'],
+                'Save was not confirmed, so the page must clearly show an error instead of staying silent.'
+            );
+        }
+    }
+}

--- a/tests/Functional/SubmitMySchedConstrTransactionTest.php
+++ b/tests/Functional/SubmitMySchedConstrTransactionTest.php
@@ -1,0 +1,78 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+// Regression test for Fix #4: SubmitMySchedConstr.php wraps its four writes
+// (ParticipantAvailability, ParticipantAvailabilityTimes per row,
+// ParticipantAvailabilityDays, and the cleanup DELETE) in a single transaction, so a
+// failure partway through can't leave partial data behind.
+//
+// There's no normal HTTP-level input that reaches a later write without also being
+// valid for the first one — the only failure mode found so far (a 4-byte UTF-8
+// character in a free-text field) fails on the very first statement, where there's
+// nothing yet to roll back. So this test forces the failure directly: temporarily
+// renaming ParticipantAvailabilityDays out of the way so its REPLACE fails *after* the
+// ParticipantAvailability and ParticipantAvailabilityTimes writes have already
+// succeeded, then checks that neither of those survived.
+final class SubmitMySchedConstrTransactionTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        TestDb::resetFixture();
+    }
+
+    protected function tearDown(): void
+    {
+        // Safety net: restore the table before dropFixture() touches it, even if the
+        // test body didn't get that far (e.g. it failed an assertion first).
+        TestDb::restoreTable('ParticipantAvailabilityDays');
+        TestDb::dropFixture();
+    }
+
+    public function testFailurePartwayThroughRollsBackEverything(): void
+    {
+        $client = new HttpClient();
+        $client->login(PLANZ_TEST_EMAIL, PLANZ_TEST_PASSWORD);
+
+        $fields = [
+            'maxprog' => '3',
+            'availstartday_1' => '1',
+            'availstarttime_1' => '1',
+            'availendday_1' => '1',
+            'availendtime_1' => '3',
+            'preventconflict' => 'SHOULD NOT SURVIVE A ROLLBACK',
+            'otherconstraints' => '',
+        ];
+        for ($day = 1; $day <= CON_NUM_DAYS; $day++) {
+            $fields["maxprogday$day"] = '1';
+        }
+        for ($i = 2; $i <= AVAILABILITY_ROWS; $i++) {
+            $fields["availstartday_$i"] = '0';
+            $fields["availstarttime_$i"] = '0';
+            $fields["availendday_$i"] = '0';
+            $fields["availendtime_$i"] = '0';
+        }
+
+        // ParticipantAvailability (write 1) and ParticipantAvailabilityTimes (write 2)
+        // will succeed normally; ParticipantAvailabilityDays (write 3) will fail
+        // because the table is gone.
+        TestDb::disableTable('ParticipantAvailabilityDays');
+        $response = $client->post('/SubmitMySchedConstr.php', $fields);
+        TestDb::restoreTable('ParticipantAvailabilityDays');
+
+        $this->assertStringContainsString(
+            'Error updating database',
+            $response['body'],
+            'A write failure partway through must surface as an error, not a silent partial save.'
+        );
+        $this->assertNull(
+            TestDb::fetchAvailability(),
+            'ParticipantAvailability must not survive the rollback, even though its own write succeeded before the failure.'
+        );
+        $this->assertSame(
+            [],
+            TestDb::fetchAvailabilityTimes(),
+            'ParticipantAvailabilityTimes must not survive the rollback, even though its own write succeeded before the failure.'
+        );
+    }
+}

--- a/tests/HttpClient.php
+++ b/tests/HttpClient.php
@@ -31,20 +31,48 @@ final class HttpClient
         return $this->request('GET', $path);
     }
 
+    // Sends a request under an explicit session id instead of this client's own cookie
+    // jar — for exercising a session forged by SessionForge (e.g. one with a stale
+    // password hash) rather than one this client actually logged in with.
     /** @param array<string,string> $fields */
-    private function request(string $method, string $path, array $fields = []): array
+    public function postWithSessionId(string $sessionId, string $path, array $fields): array
+    {
+        return $this->request('POST', $path, $fields, "PHPSESSID=$sessionId");
+    }
+
+    // The PHPSESSID this client is currently using, if it has made any request yet.
+    public function sessionId(): ?string
+    {
+        if (!is_file($this->cookieJar)) {
+            return null;
+        }
+        foreach (file($this->cookieJar) as $line) {
+            if (preg_match('/\bPHPSESSID\t(\S+)/', $line, $matches)) {
+                return $matches[1];
+            }
+        }
+        return null;
+    }
+
+    /** @param array<string,string> $fields */
+    private function request(string $method, string $path, array $fields = [], ?string $rawCookie = null): array
     {
         $ch = curl_init($this->baseUrl . $path);
-        curl_setopt_array($ch, [
+        $options = [
             CURLOPT_RETURNTRANSFER => true,
-            CURLOPT_COOKIEJAR => $this->cookieJar,
-            CURLOPT_COOKIEFILE => $this->cookieJar,
             // The test target is either a local DDEV site (self-signed cert) or a
             // plain http:// PHP built-in server in CI — never a public endpoint.
             CURLOPT_SSL_VERIFYPEER => false,
             CURLOPT_SSL_VERIFYHOST => 0,
             CURLOPT_TIMEOUT => 15,
-        ]);
+        ];
+        if ($rawCookie !== null) {
+            $options[CURLOPT_COOKIE] = $rawCookie;
+        } else {
+            $options[CURLOPT_COOKIEJAR] = $this->cookieJar;
+            $options[CURLOPT_COOKIEFILE] = $this->cookieJar;
+        }
+        curl_setopt_array($ch, $options);
         if ($method === 'POST') {
             curl_setopt($ch, CURLOPT_POST, true);
             curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($fields));

--- a/tests/HttpClient.php
+++ b/tests/HttpClient.php
@@ -1,0 +1,70 @@
+<?php
+// Minimal curl-based HTTP client for Functional tests. Deliberately dependency-free
+// (no Guzzle) so the root composer.json only needs PHPUnit.
+
+final class HttpClient
+{
+    private string $baseUrl;
+    private string $cookieJar;
+
+    public function __construct(?string $baseUrl = null)
+    {
+        $this->baseUrl = rtrim($baseUrl ?? getenv('PLANZ_TEST_BASE_URL') ?: 'https://planz.ddev.site', '/');
+        $this->cookieJar = tempnam(sys_get_temp_dir(), 'planz-test-cookies-');
+    }
+
+    public function __destruct()
+    {
+        if (is_file($this->cookieJar)) {
+            unlink($this->cookieJar);
+        }
+    }
+
+    /** @param array<string,string> $fields */
+    public function post(string $path, array $fields): array
+    {
+        return $this->request('POST', $path, $fields);
+    }
+
+    public function get(string $path): array
+    {
+        return $this->request('GET', $path);
+    }
+
+    /** @param array<string,string> $fields */
+    private function request(string $method, string $path, array $fields = []): array
+    {
+        $ch = curl_init($this->baseUrl . $path);
+        curl_setopt_array($ch, [
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_COOKIEJAR => $this->cookieJar,
+            CURLOPT_COOKIEFILE => $this->cookieJar,
+            // The test target is either a local DDEV site (self-signed cert) or a
+            // plain http:// PHP built-in server in CI — never a public endpoint.
+            CURLOPT_SSL_VERIFYPEER => false,
+            CURLOPT_SSL_VERIFYHOST => 0,
+            CURLOPT_TIMEOUT => 15,
+        ]);
+        if ($method === 'POST') {
+            curl_setopt($ch, CURLOPT_POST, true);
+            curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($fields));
+        }
+        $body = curl_exec($ch);
+        if ($body === false) {
+            $error = curl_error($ch);
+            curl_close($ch);
+            throw new RuntimeException("HTTP $method $path failed: $error");
+        }
+        $status = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
+        return ['status' => $status, 'body' => $body];
+    }
+
+    public function login(string $badgeidOrEmail, string $password): array
+    {
+        return $this->post('/doLogin.php', [
+            'badgeid' => $badgeidOrEmail,
+            'passwd' => $password,
+        ]);
+    }
+}

--- a/tests/SessionForge.php
+++ b/tests/SessionForge.php
@@ -1,0 +1,39 @@
+<?php
+// Produces a real, valid PlanZ session (via an actual login) and then lets a test
+// mutate it before saving it under a fresh session id — for exercising session states
+// that are impractical to reach through the normal login flow, like "the participant's
+// password changed after they logged in" or "their permission set changed mid-session".
+//
+// This reads and writes real PHP session files via the session_* functions (not by
+// guessing paths), so it works the same way locally and in CI regardless of
+// session.save_path.
+final class SessionForge
+{
+    /**
+     * @param callable(array<string,mixed> &$session): void $mutate Receives the real,
+     *     logged-in session data by reference; mutate it however the test needs.
+     */
+    public static function create(callable $mutate): string
+    {
+        $client = new HttpClient();
+        $client->login(PLANZ_TEST_EMAIL, PLANZ_TEST_PASSWORD);
+        $realSessionId = $client->sessionId();
+        if ($realSessionId === null) {
+            throw new RuntimeException('Login did not produce a session cookie — cannot forge a session from it.');
+        }
+
+        session_id($realSessionId);
+        session_start();
+        $sessionData = $_SESSION;
+        session_abort(); // discard without touching the real session file
+
+        $forgedSessionId = bin2hex(random_bytes(16));
+        session_id($forgedSessionId);
+        session_start();
+        $_SESSION = $sessionData;
+        $mutate($_SESSION);
+        session_write_close();
+
+        return $forgedSessionId;
+    }
+}

--- a/tests/TestDb.php
+++ b/tests/TestDb.php
@@ -1,0 +1,97 @@
+<?php
+// Direct DB access for Functional tests: sets up and tears down the dedicated
+// PLANZ_TEST_BADGEID fixture, and lets tests assert on persisted state independently
+// of whatever the app's HTTP response claims happened.
+
+final class TestDb
+{
+    private static ?mysqli $connection = null;
+
+    public static function connection(): mysqli
+    {
+        if (self::$connection === null) {
+            self::$connection = mysqli_connect(DBHOSTNAME, DBUSERID, DBPASSWORD, DBDB);
+            if (!self::$connection) {
+                throw new RuntimeException('Could not connect to the test database: ' . mysqli_connect_error());
+            }
+            mysqli_set_charset(self::$connection, 'utf8');
+        }
+        return self::$connection;
+    }
+
+    // Removes any trace of the fixture participant, then recreates it with a known
+    // password and the 'my_availability' permission. Safe to call before every test.
+    public static function resetFixture(): void
+    {
+        $db = self::connection();
+        $badgeid = PLANZ_TEST_BADGEID;
+
+        foreach ([
+            'ParticipantAvailabilityTimes',
+            'ParticipantAvailabilityDays',
+            'ParticipantAvailability',
+            'UserHasPermissionRole',
+            'CongoDump',
+            'Participants',
+        ] as $table) {
+            mysqli_query($db, "DELETE FROM `$table` WHERE badgeid = '$badgeid'");
+        }
+
+        mysqli_query($db, "
+            INSERT INTO Participants (badgeid, password, pubsname, data_retention)
+            VALUES ('$badgeid', '" . PLANZ_TEST_PASSWORD_HASH . "', 'PlanZ Test User', 1)
+        ");
+        mysqli_query($db, "
+            INSERT INTO CongoDump (badgeid, firstname, lastname, badgename, email)
+            VALUES ('$badgeid', 'PlanZ', 'Test User', 'PlanZ Test User', '" . PLANZ_TEST_EMAIL . "')
+        ");
+        // Role 3 = 'Program Participant', which grants the 'my_availability' permission
+        // atom for phase 3 ('Availability') — see Install/EmptyDbase.dump.
+        mysqli_query($db, "INSERT INTO UserHasPermissionRole (badgeid, permroleid) VALUES ('$badgeid', 3)");
+        // The 'Availability' phase isn't current by default in a fresh install; turn
+        // it on so the fixture user actually has access to My Availability.
+        mysqli_query($db, "UPDATE Phases SET current = 1 WHERE phaseid = 3");
+    }
+
+    public static function dropFixture(): void
+    {
+        $db = self::connection();
+        $badgeid = PLANZ_TEST_BADGEID;
+        foreach ([
+            'ParticipantAvailabilityTimes',
+            'ParticipantAvailabilityDays',
+            'ParticipantAvailability',
+            'UserHasPermissionRole',
+            'CongoDump',
+            'Participants',
+        ] as $table) {
+            mysqli_query($db, "DELETE FROM `$table` WHERE badgeid = '$badgeid'");
+        }
+    }
+
+    public static function fetchAvailability(): ?array
+    {
+        $db = self::connection();
+        $badgeid = PLANZ_TEST_BADGEID;
+        $result = mysqli_query($db, "SELECT * FROM ParticipantAvailability WHERE badgeid = '$badgeid'");
+        $row = mysqli_fetch_assoc($result);
+        return $row ?: null;
+    }
+
+    public static function fetchAvailabilityTimes(): array
+    {
+        $db = self::connection();
+        $badgeid = PLANZ_TEST_BADGEID;
+        $result = mysqli_query($db, "
+            SELECT availabilitynum, TIME_FORMAT(starttime, '%T') AS starttime, TIME_FORMAT(endtime, '%T') AS endtime
+            FROM ParticipantAvailabilityTimes
+            WHERE badgeid = '$badgeid'
+            ORDER BY availabilitynum
+        ");
+        $rows = [];
+        while ($row = mysqli_fetch_assoc($result)) {
+            $rows[] = $row;
+        }
+        return $rows;
+    }
+}

--- a/tests/TestDb.php
+++ b/tests/TestDb.php
@@ -78,6 +78,26 @@ final class TestDb
         return $row ?: null;
     }
 
+    // Renames a table out of the way so the next write against it fails — used to
+    // prove SubmitMySchedConstr.php's transaction actually rolls back a failure that
+    // happens partway through the save, not just on the very first statement.
+    public static function disableTable(string $table): void
+    {
+        $db = self::connection();
+        mysqli_query($db, "RENAME TABLE `$table` TO `{$table}_test_disabled`");
+    }
+
+    // Idempotent: safe to call even if the table was never disabled, or was already
+    // restored, so it's safe to use as an unconditional tearDown() safety net.
+    public static function restoreTable(string $table): void
+    {
+        $db = self::connection();
+        $result = mysqli_query($db, "SHOW TABLES LIKE '{$table}_test_disabled'");
+        if (mysqli_num_rows($result) > 0) {
+            mysqli_query($db, "RENAME TABLE `{$table}_test_disabled` TO `$table`");
+        }
+    }
+
     public static function fetchAvailabilityTimes(): array
     {
         $db = self::connection();

--- a/tests/Unit/ConvertTimestampToTimeindexTest.php
+++ b/tests/Unit/ConvertTimestampToTimeindexTest.php
@@ -1,0 +1,62 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+// Exercises webpages/my_sched_constr_func.php's convert_timestamp_to_timeindex(),
+// which turns a stored "hh:mm:ss" / "hhh:mm:ss" availability timestamp back into a
+// (day, Times-table-index) pair. It's pure given a DOMXPath, so we build a small
+// synthetic Times XML document rather than hitting the real DB.
+final class ConvertTimestampToTimeindexTest extends TestCase
+{
+    private function buildTimesXPath(): DOMXPath
+    {
+        $xml = new DOMDocument();
+        $doc = $xml->appendChild($xml->createElement('doc'));
+        $query = $doc->appendChild($xml->createElement('query'));
+
+        $rows = [
+            ['timeid' => 1, 'timevalue' => '10:00:00', 'next_day' => 0, 'avail_start' => 1, 'avail_end' => 0],
+            ['timeid' => 2, 'timevalue' => '12:00:00', 'next_day' => 0, 'avail_start' => 1, 'avail_end' => 1],
+            ['timeid' => 3, 'timevalue' => '02:00:00', 'next_day' => 1, 'avail_start' => 0, 'avail_end' => 1],
+        ];
+        foreach ($rows as $attributes) {
+            $row = $query->appendChild($xml->createElement('row'));
+            foreach ($attributes as $name => $value) {
+                $row->setAttribute($name, (string) $value);
+            }
+        }
+
+        return new DOMXPath($xml);
+    }
+
+    public function testSameDayStartTime(): void
+    {
+        $xpath = $this->buildTimesXPath();
+
+        $result = convert_timestamp_to_timeindex($xpath, '10:00:00', true);
+
+        // day is computed via floor(), so it comes back as a float — compare by value.
+        $this->assertEquals(1, $result['day']);
+        $this->assertSame('1', $result['hour']);
+    }
+
+    public function testHourPastMidnightRollsOverToNextDay(): void
+    {
+        $xpath = $this->buildTimesXPath();
+
+        // 26:00:00 = 2am, one day after the con's day-1 start.
+        $result = convert_timestamp_to_timeindex($xpath, '26:00:00', false);
+
+        $this->assertEquals(1, $result['day']);
+        $this->assertSame('3', $result['hour']);
+    }
+
+    public function testTimeNotInTimesTableReturnsUnsetIndex(): void
+    {
+        $xpath = $this->buildTimesXPath();
+
+        $result = convert_timestamp_to_timeindex($xpath, '23:15:00', true);
+
+        $this->assertSame('0', $result['hour']);
+    }
+}

--- a/tests/Unit/ValidateParticipantAvailabilityTest.php
+++ b/tests/Unit/ValidateParticipantAvailabilityTest.php
@@ -1,0 +1,86 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+// Exercises webpages/validation_functions.php's validate_participant_availability()
+// directly, with no DB or HTTP involved. The function reads/writes through
+// `global $partAvail, $messages;`, so tests populate $GLOBALS['partAvail'] before
+// calling it, matching how SubmitMySchedConstr.php uses it.
+final class ValidateParticipantAvailabilityTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['partAvail'], $GLOBALS['messages']);
+    }
+
+    private function baseValidAvail(): array
+    {
+        $avail = [
+            'maxprog' => 3,
+            'numkidsfasttrack' => 0,
+        ];
+        for ($day = 1; $day <= CON_NUM_DAYS; $day++) {
+            $avail["maxprogday$day"] = 1;
+        }
+        for ($i = 1; $i <= AVAILABILITY_ROWS; $i++) {
+            $avail["availstartday_$i"] = 0;
+            $avail["availstarttime_$i"] = 0;
+            $avail["availendday_$i"] = 0;
+            $avail["availendtime_$i"] = 0;
+        }
+        return $avail;
+    }
+
+    public function testFullyBlankScheduleIsValid(): void
+    {
+        $GLOBALS['partAvail'] = $this->baseValidAvail();
+        $this->assertTrue(validate_participant_availability());
+    }
+
+    public function testOneCompleteAvailabilitySlotIsValid(): void
+    {
+        $avail = $this->baseValidAvail();
+        $avail['availstartday_1'] = 1;
+        $avail['availstarttime_1'] = 1;
+        $avail['availendday_1'] = 1;
+        $avail['availendtime_1'] = 3;
+        $GLOBALS['partAvail'] = $avail;
+
+        $this->assertTrue(validate_participant_availability());
+    }
+
+    public function testPartiallyFilledSlotIsRejected(): void
+    {
+        if (CON_NUM_DAYS <= 1) {
+            $this->markTestSkipped('Day fields are only collected for a multi-day con.');
+        }
+        $avail = $this->baseValidAvail();
+        // Start day/time set, but end day/time left blank.
+        $avail['availstartday_1'] = 1;
+        $avail['availstarttime_1'] = 1;
+        $GLOBALS['partAvail'] = $avail;
+
+        $this->assertFalse(validate_participant_availability());
+    }
+
+    public function testEndBeforeStartIsRejected(): void
+    {
+        $avail = $this->baseValidAvail();
+        $avail['availstartday_1'] = 2;
+        $avail['availstarttime_1'] = 3;
+        $avail['availendday_1'] = 2;
+        $avail['availendtime_1'] = 1; // ends before it starts, same day
+        $GLOBALS['partAvail'] = $avail;
+
+        $this->assertFalse(validate_participant_availability());
+    }
+
+    public function testMaxProgOverLimitIsRejected(): void
+    {
+        $avail = $this->baseValidAvail();
+        $avail['maxprog'] = PREF_TTL_SESNS_LMT + 1;
+        $GLOBALS['partAvail'] = $avail;
+
+        $this->assertFalse(validate_participant_availability());
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,39 @@
+<?php
+// PHPUnit bootstrap for PlanZ.
+//
+// This deliberately does NOT require CommonCode.php or PartCommonCode.php: those
+// files call session_start() and connect to the database as a side effect of being
+// included, which is wrong for fast, isolated unit tests. Instead we pull in just
+// the pure function-definition files (no top-level side effects) plus the app's
+// config constants, and let Functional tests open their own DB/HTTP connections
+// explicitly via tests/TestDb.php and tests/HttpClient.php.
+
+define('PLANZ_ROOT', dirname(__DIR__) . '/webpages');
+
+// Dedicated fixture participant used by Functional tests. Never reuse a real or
+// manually-tested account (e.g. someone@somewhere.com) here: tests delete and
+// recreate this badgeid's rows on every run.
+define('PLANZ_TEST_BADGEID', 'PLNZTEST1');
+define('PLANZ_TEST_PASSWORD', 'PlanZTestPass1!');
+define('PLANZ_TEST_PASSWORD_HASH', '$2y$10$rbqE07ER2kV.n3jqHdlqge41GqQRvGf9Z7wph/GsNY5gmfWP10NMK');
+define('PLANZ_TEST_EMAIL', 'planz-test-user@example.invalid');
+
+require_once PLANZ_ROOT . '/Constants.php';
+
+// Config constants (CON_NUM_DAYS, PREF_TTL_SESNS_LMT, AVAILABILITY_ROWS, ...) come
+// from webpages/config/db_name.php. Locally this already exists (DDEV setup); in CI
+// the workflow generates one pointed at the CI database before tests run.
+if (file_exists(PLANZ_ROOT . '/config/db_name.php')) {
+    require_once PLANZ_ROOT . '/config/db_name.php';
+} else {
+    fwrite(STDERR, "webpages/config/db_name.php not found — copy webpages/config/db_name_sample.php" .
+        " and configure it before running tests.\n");
+    exit(1);
+}
+
+require_once PLANZ_ROOT . '/data_functions.php';
+require_once PLANZ_ROOT . '/validation_functions.php';
+require_once PLANZ_ROOT . '/my_sched_constr_func.php';
+
+require_once __DIR__ . '/TestDb.php';
+require_once __DIR__ . '/HttpClient.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -37,3 +37,4 @@ require_once PLANZ_ROOT . '/my_sched_constr_func.php';
 
 require_once __DIR__ . '/TestDb.php';
 require_once __DIR__ . '/HttpClient.php';
+require_once __DIR__ . '/SessionForge.php';

--- a/webpages/SubmitMySchedConstr.php
+++ b/webpages/SubmitMySchedConstr.php
@@ -41,6 +41,13 @@ if ($status == false) {
     $message_error = "The data you entered was incorrect.  Database not updated.<br />" . $messages; // error message
     unset($messages);
 } else {  /* Update DB */
+    // The four writes below (ParticipantAvailability, ParticipantAvailabilityTimes per
+    // row, ParticipantAvailabilityDays, and the DELETE of cleared rows) used to each
+    // commit independently. A failure partway through — e.g. row 3 of
+    // ParticipantAvailabilityTimes — could leave the main record and rows 1-2 saved
+    // while the rest of the submission was silently dropped. Wrapping them in a single
+    // transaction makes the save atomic: either all of it lands, or none of it does.
+    mysqli_begin_transaction($linki);
     $query = "REPLACE ParticipantAvailability SET ";
     $query .= "badgeid='$badgeid', ";
     $query .= "maxprog={$partAvail["maxprog"]}, ";
@@ -48,6 +55,7 @@ if ($status == false) {
     $query .= "otherconstraints=\"" . mysqli_real_escape_string($linki, $partAvail["otherconstraints"]) . "\", ";
     $query .= "numkidsfasttrack={$partAvail["numkidsfasttrack"]};";
     if (!mysqli_query($linki, $query)) {
+        mysqli_rollback($linki);
         $message = $query . "<br />Error updating database.  Database not updated.";
         RenderError($message);
         exit();
@@ -76,6 +84,7 @@ if ($status == false) {
             $query = "REPLACE ParticipantAvailabilityTimes SET ";
             $query .= "badgeid=\"$badgeid\",availabilitynum=$i,starttime=\"$starttime\",endtime=\"$endtime\"";
             if (!mysqli_query($linki, $query)) {
+                mysqli_rollback($linki);
                 $message = $query . "<br />Error updating database.  Database not updated.";
                 RenderError($message);
                 exit();
@@ -90,6 +99,7 @@ if ($status == false) {
         }
         $query = substr($query, 0, -1); // remove extra trailing comma
         if (!mysqli_query($linki, $query)) {
+            mysqli_rollback($linki);
             $message = $query . "<br />Error updating database.  Database not updated.";
             RenderError($message);
             exit();
@@ -107,10 +117,14 @@ if ($status == false) {
     if ($deleteany) {
         $query = substr($query, 0, -2) . ");\n";
         // error_log($query); for debugging only
-        if (!mysqli_query_with_error_handling($query, true)) {
+        if (!mysqli_query($linki, $query)) {
+            mysqli_rollback($linki);
+            $message = $query . "<br />Error updating database.  Database not updated.";
+            RenderError($message);
             exit();
         }
     }
+    mysqli_commit($linki);
     if (!$partAvail = retrieve_participantAvailability_from_db($badgeid, true)) {
         exit();
     }

--- a/webpages/SubmitMySchedConstr.php
+++ b/webpages/SubmitMySchedConstr.php
@@ -5,6 +5,20 @@ $title = "My Availability";
 require('PartCommonCode.php'); // initialize db; check login;
 //                                  set $badgeid from session
 require('my_sched_constr_func.php');
+// Mirrors the check in my_sched_constr.php's GET path. Without this, a session that
+// went stale between page-load and submit (e.g. isLoggedIn()'s password re-check fails
+// because the participant's password changed) wasn't caught until renderMySchedConstr.php
+// called participant_header() at the very end — by which point the writes below had
+// already run, and participant_header() exits before the $message/$message_error block
+// ever renders, so the user saw only "Session expired" with no indication whether their
+// save had worked. may_I() alone isn't enough here: it only reads the session's cached
+// permission_set, which stays valid even after the underlying password/session goes
+// stale, so isLoggedIn() (the same check participant_header() relies on) is required too.
+if (!isLoggedIn() || !may_I('my_availability')) {
+    $message_error = "You do not currently have permission to view this page.<BR>\n";
+    RenderError($message_error);
+    exit();
+}
 $partAvail = get_participant_availability_from_post();
 $timesXML = retrieve_timesXML();
 $status = validate_participant_availability(); /* return true if OK.  Store error messages in

--- a/webpages/db_functions.php
+++ b/webpages/db_functions.php
@@ -278,13 +278,22 @@ if (USE_REG_SYSTEM === TRUE) {
 
 function prepare_db_and_more() {
     global $con_start_php_timestamp, $linki, $fatalError;
+    // As of PHP 8.1, mysqli defaults to throwing mysqli_sql_exception on error instead
+    // of returning false. This app's error handling throughout (mysqli_query_with_error_handling(),
+    // the "if (!mysqli_query(...))" checks in Submit*.php, isLoggedIn(), etc.) was written
+    // for the pre-8.1 "returns false" behavior and depends on it to show a friendly error
+    // instead of an uncaught fatal error. Restore that behavior explicitly.
+    mysqli_report(MYSQLI_REPORT_OFF);
     $linki = mysqli_connect(DBHOSTNAME, DBUSERID, DBPASSWORD, DBDB);
     if (!$linki) {
         $fatalError = true;
         return false;
     }
     date_default_timezone_set(PHP_DEFAULT_TIMEZONE);
-    if (mysqli_set_charset($linki, "utf8") === false) {
+    // Matches the utf8mb4 conversion applied by Install/Upgrade_dbase/100ZED_utf8mb4_migration.sql.
+    // Declaring the connection as the old 3-byte "utf8" here would still reject 4-byte
+    // characters (e.g. emoji) even though the columns can now store them.
+    if (mysqli_set_charset($linki, "utf8mb4") === false) {
         $fatalError = true;
         return false;
     }


### PR DESCRIPTION
## Summary of change
Fixes a reported bug where the My Availability page could appear to save successfully while silently losing the participant's data, with no error shown.

- PHP 8.1 mysqli compatibility (webpages/db_functions.php): PHP 8.1 changed mysqli's default error-reporting mode to throw an exception on query failure instead of returning false, but this app's error handling was written for the old behavior. A failing query (e.g. an emoji in a free-text field, which the database couldn't yet store) crashed with an uncaught exception instead of showing the app's intended friendly error - a blank/broken page with the save silently dropped. Restored the original behavior with mysqli_report(MYSQLI_REPORT_OFF).
- Database charset migration (Install/Upgrade_dbase/100ZED_utf8mb4_migration.sql, webpages/db_functions.php): converted the database and all 83 tables from utf8 (3-byte) to utf8mb4 (4-byte), and updated the connection charset to match, so participants can actually save emoji and other characters outside the Basic Multilingual Plane instead of the save being rejected.
- Stale session handling (webpages/SubmitMySchedConstr.php): the save endpoint used to write to the database before checking whether the session was still valid — a session that went stale between page-load and submit (password changed, permission revoked) could have its write silently succeed or fail with the confirmation/error message never reaching the user. Added an upfront isLoggedIn()/may_I('my_availability') check, mirroring the page's own GET-side guard, so a stale session is caught before any writes happen.
- Atomic saves (webpages/SubmitMySchedConstr.php): the four writes that make up a save (main record, per-row availability times, daily limits, and cleanup of cleared rows) previously committed independently, so a failure partway through could leave partial data behind. Wrapped them in a single transaction so a save either fully succeeds or fully rolls back.

## Automated testing
Includes a new PHPUnit test suite (tests/) and GitHub Actions CI workflow covering all four fixes, including regression tests for each bug. I hope that later changes will expand on test coverage.

## Manual test steps
0. Setup
  - Apply the DB migration: php scripts/db_update.php (picks up 100ZED_utf8mb4_migration.sql).
  - Deploy the updated webpages/db_functions.php and webpages/SubmitMySchedConstr.php.

1. Multi-byte characters save correctly (Fixes #1 + #2)
  - Log in as a participant with the my_availability permission, go to My Availability.
  - In "Please don't schedule me for a session that conflicts with," type something containing an emoji, e.g. No panels before 10am 😀.
  - Fill in a valid availability slot, click Save.
  - Expect: a green "Database updated successfully" message, and the emoji still showing in the text box.
  - Reload the page (fresh GET, not just re-render): confirm the emoji is still there — this is the real check, since the old bug could show a false confirmation.

2. Ordinary save still works (regression check)
  - On the same page, set a total session max, a couple of daily maxes, one or two availability slots, and plain-text values in both free-text boxes. Save.
  - Expect: success message, and reloading the page shows exactly what was entered — confirms the migration/charset change didn't break the normal path.

3. Stale session no longer saves silently (Fix #3). This needs two browser contexts (or a staff console) since the trigger is the session going stale mid-visit:
  - As the participant, open My Availability and start filling in the form, but don't submit yet.
  - In a separate window, as staff, either reset that participant's password or remove their my_availability permission (e.g. via the role/permissions admin page).
  - Back in the participant's tab, click Save.
  - Expect: a clear message — either "Session expired. Please log in again." or "You do not currently have permission to view this page." — never a page that looks blank or like nothing happened.
  - Check the Availability report (or the DB) for that participant: confirm the values from step 1 were not saved.
  
  4. A failure partway through doesn't leave partial data (Fix #4). This one is impractical to trigger through the UI - there's no ordinary input that makes the second or third write fail without the first one also failing, so there's nothing to click through. It's covered by an automated test that deliberately breaks a table mid-save and confirms a full rollback (tests/Functional/SubmitMySchedConstrTransactionTest.php). If you want to spot-check it by hand anyway, only do this against a disposable/dev database:
  - RENAME TABLE ParticipantAvailabilityDays TO ParticipantAvailabilityDays_disabled;
  - Submit a valid save through the UI.
  - Expect: an "Error updating database" message, and — checking the DB directly — no row in ParticipantAvailability or ParticipantAvailabilityTimes either, even though those writes would have succeeded on their own.
  - RENAME TABLE ParticipantAvailabilityDays_disabled TO ParticipantAvailabilityDays; to restore.

**Note:** This change was assisted by AI tools, which a mix of human written and automated code, but all changes have been manually reviewed.